### PR TITLE
Fix config window for batch editor

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -1452,7 +1452,9 @@ class App(tk.Tk):
             self.creative_config_btn.config(state='disabled')
 
     def open_window(self, window_class, *args):
-        if window_class not in [ExpansionBuilderWindow] and (not self.folder_path.get() or not os.path.isdir(self.folder_path.get())):
+        if window_class not in [ExpansionBuilderWindow, CreativeModeConfigWindow] and (
+            not self.folder_path.get() or not os.path.isdir(self.folder_path.get())
+        ):
             messagebox.showerror("Error", "Please select a valid source folder first.", parent=self.root)
             return
         try:


### PR DESCRIPTION
## Summary
- allow `CreativeModeConfigWindow` to open without requiring a source folder

## Testing
- `python -m py_compile 'Gemini wav_TO_XpmV2.py' 'batch_program_editor.py' 'batch_packager.py'`

------
https://chatgpt.com/codex/tasks/task_e_6867c68f12c0832bb8cec1c253861f6e