### PR TITLE
Fix advanced params when exporting XPMs

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -49,7 +49,11 @@ class TextHandler(logging.Handler):
             self.text_widget.yview(tk.END)
         self.text_widget.after(0, append)
 
-from firmware_profiles import get_pad_settings, get_program_parameters as fw_program_parameters
+from firmware_profiles import (
+    get_pad_settings,
+    get_program_parameters as fw_program_parameters,
+    ADVANCED_INSTRUMENT_PARAMS,
+)
 
 
 def build_program_pads_json(firmware, mappings=None):
@@ -1078,14 +1082,38 @@ class InstrumentBuilder:
 
     def build_instrument_element(self, parent, num, low, high):
         instrument = ET.SubElement(parent, 'Instrument', {'number': str(num)})
-        params = {
-            'Polyphony': str(self.options.polyphony), 'LowNote': str(low), 'HighNote': str(high),
-            'Volume': '1.0', 'Pan': '0.5', 'Tune': '0.0', 'MuteGroup': '0', 'VoiceOverlap': 'Poly',
-            'VolumeAttack': '0.0', 'VolumeDecay': '0.0', 'VolumeSustain': '1.0', 'VolumeRelease': '0.05',
-            'FilterType': 'Off', 'Cutoff': '1.0', 'Resonance': '0.0', 'FilterKeytrack': '0.0',
-            'FilterAttack': '0.0', 'FilterDecay': '0.0', 'FilterSustain': '1.0', 'FilterRelease': '0.0',
-            'FilterEnvAmount': '0.0'
-        }
+        engine = get_pad_settings(self.options.firmware_version).get('engine')
+        if engine == 'advanced' and ADVANCED_INSTRUMENT_PARAMS:
+            params = ADVANCED_INSTRUMENT_PARAMS.copy()
+            params.update({
+                'Polyphony': str(self.options.polyphony),
+                'LowNote': str(low),
+                'HighNote': str(high),
+            })
+        else:
+            params = {
+                'Polyphony': str(self.options.polyphony),
+                'LowNote': str(low),
+                'HighNote': str(high),
+                'Volume': '1.0',
+                'Pan': '0.5',
+                'Tune': '0.0',
+                'MuteGroup': '0',
+                'VoiceOverlap': 'Poly',
+                'VolumeAttack': '0.0',
+                'VolumeDecay': '0.0',
+                'VolumeSustain': '1.0',
+                'VolumeRelease': '0.05',
+                'FilterType': 'Off',
+                'Cutoff': '1.0',
+                'Resonance': '0.0',
+                'FilterKeytrack': '0.0',
+                'FilterAttack': '0.0',
+                'FilterDecay': '0.0',
+                'FilterSustain': '1.0',
+                'FilterRelease': '0.0',
+                'FilterEnvAmount': '0.0',
+            }
         for key, val in params.items():
             ET.SubElement(instrument, key).text = val
         return instrument

--- a/firmware_profiles.py
+++ b/firmware_profiles.py
@@ -64,6 +64,31 @@ def _load_advanced_params():
 
 ADVANCED_PROGRAM_PARAMS = _load_advanced_params()
 
+# Extract default instrument parameter values from the reference XPM. Only
+# capture simple text elements so they can be merged directly with the
+# dictionary used in InstrumentBuilder.
+def _load_advanced_instrument_params():
+    import os
+    import xml.etree.ElementTree as ET
+
+    path = os.path.join(os.path.dirname(__file__), 'Advanced keygroup.xpm')
+    if not os.path.exists(path):
+        return {}
+
+    root = ET.parse(path).getroot()
+    inst = root.find('.//Instrument')
+    params = {}
+    if inst is None:
+        return params
+
+    for child in inst:
+        if len(list(child)) == 0:
+            params[child.tag] = child.text or ''
+    return params
+
+
+ADVANCED_INSTRUMENT_PARAMS = _load_advanced_instrument_params()
+
 # Some older firmware do not support the newer LFO/aftertouch parameters.
 LEGACY_REMOVE_KEYS = {
     '2.3.0.0': ['KeygroupWheelToLfo2', 'KeygroupAftertouchToFilter2'],


### PR DESCRIPTION
## Summary
- load default instrument settings from `Advanced keygroup.xpm`
- import these parameters in main GUI script
- write advanced instrument fields when creating a program

## Testing
- `python -m py_compile "Gemini wav_TO_XpmV2.py" "batch_packager.py" "batch_program_editor.py" "firmware_profiles.py"`

------
https://chatgpt.com/codex/tasks/task_e_6867d2545afc832bb5546b1a07997965