### PR TITLE
Fix SmartSplitWindow apply_split

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -859,7 +859,6 @@ class SmartSplitWindow(tk.Toplevel):
         ttk.Button(btn_frame, text="Cancel", command=self.destroy).pack(side="right", padx=5)
 
     def apply_split(self):
-        folder = self.master.folder_path.get()
         mode = self.split_mode.get()
         self.destroy()
         self.master.run_batch_process(split_files_smartly, mode)


### PR DESCRIPTION
## Summary
- remove unused `folder` variable in `SmartSplitWindow.apply_split`

## Testing
- `python -m py_compile 'Gemini wav_TO_XpmV2.py'`

------
https://chatgpt.com/codex/tasks/task_e_6867d9bd5cd8832b94201e04512a4c6e