### PR TITLE
Remove unused batch_program_editor import

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -19,7 +19,6 @@ import struct
 import re
 import json
 import zipfile
-import batch_program_editor
 
 # --- Application Configuration ---
 APP_VERSION = "22.4"


### PR DESCRIPTION
## Summary
- clean up `Gemini wav_TO_XpmV2.py` by removing unused `batch_program_editor` import

## Testing
- `python -m py_compile "Gemini wav_TO_XpmV2.py"`

------
https://chatgpt.com/codex/tasks/task_e_6867da7e1004832b8298bbe57e6a80cc