### PR TITLE
Add drum kit grouping feature

### DIFF
--- a/drumkit_grouping.py
+++ b/drumkit_grouping.py
@@ -1,0 +1,25 @@
+import os
+import glob
+import re
+from collections import defaultdict
+
+
+def extract_group_name(filename: str) -> str:
+    """Return a simplified group name based on underscores, spaces and digits."""
+    base = os.path.splitext(os.path.basename(filename))[0]
+    base = re.sub(r'([A-G][#b]?[-_]?\d+)$', '', base, flags=re.IGNORECASE)
+    base = re.sub(r'\d+$', '', base)
+    parts = re.split(r'[ _-]+', base)
+    return parts[0].lower() if parts else base.lower()
+
+
+def group_similar_files(folder: str) -> dict:
+    """Group WAV files in a folder by similar names."""
+    groups = defaultdict(list)
+    for wav in glob.glob(os.path.join(folder, '*.wav')):
+        name = extract_group_name(wav)
+        groups[name].append(os.path.relpath(wav, folder))
+    for files in groups.values():
+        files.sort()
+    return groups
+


### PR DESCRIPTION
## Summary
- add new `drumkit_grouping.py` for grouping samples by name
- support new 'drum-kit' mode in `Gemini wav_TO_XpmV2.py`
- assign sequential MIDI notes from C3 in drum kit mode and force C3 for one-shots
- expose drum kit build option in the GUI

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6867df085e40832ba1ee4ac46ac7b543