### PR TITLE
Add multi-sample grouping window

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -20,6 +20,7 @@ import re
 import json
 import zipfile
 from drumkit_grouping import group_similar_files
+from multi_sample_builder import MultiSampleBuilderWindow
 
 # --- Application Configuration ---
 APP_VERSION = "22.4"
@@ -1023,7 +1024,7 @@ class InstrumentBuilder:
         finally:
             self.app.progress["value"] = 0
             
-    def _create_xpm(self, program_name, sample_files, output_folder, mode):
+    def _create_xpm(self, program_name, sample_files, output_folder, mode, midi_notes=None):
         """Creates a single XPM file from a group of samples using robust XML construction."""
         try:
             sample_infos = []
@@ -1032,7 +1033,9 @@ class InstrumentBuilder:
                 abs_path = os.path.join(self.folder_path, file_path) if not os.path.isabs(file_path) else file_path
                 info = self.validate_sample_info(abs_path)
                 if info.get('is_valid'):
-                    if mode == 'drum-kit':
+                    if midi_notes and idx < len(midi_notes):
+                        midi_note = midi_notes[idx]
+                    elif mode == 'drum-kit':
                         midi_note = min(start_note + idx, 127)
                     elif mode == 'one-shot':
                         midi_note = start_note
@@ -1552,7 +1555,7 @@ class App(tk.Tk):
         threading.Thread(target=builder.create_instruments, args=(mode,), daemon=True).start()
 
     def build_multi_sample_instruments(self):
-        self.build_instruments('multi-sample')
+        self.open_window(MultiSampleBuilderWindow, InstrumentBuilder, InstrumentOptions)
 
     def build_one_shot_instruments(self):
         self.build_instruments('one-shot')

--- a/multi_sample_builder.py
+++ b/multi_sample_builder.py
@@ -1,0 +1,163 @@
+import os
+import glob
+import tkinter as tk
+from tkinter import ttk, messagebox, simpledialog
+
+class MultiSampleBuilderWindow(tk.Toplevel):
+    """Interactive tool for grouping samples and creating multi-sample instruments."""
+
+    def __init__(self, master, builder_cls, options_cls):
+        super().__init__(master.root)
+        self.master = master
+        self.builder_cls = builder_cls
+        self.options_cls = options_cls
+        self.title("Multi-Sample Instrument Builder")
+        self.geometry("750x500")
+        self.groups = {}
+        self.unassigned = []
+        self.group_var = tk.StringVar()
+        self.map_var = tk.StringVar(value="all")
+        self.create_widgets()
+        self.load_files()
+
+    def create_widgets(self):
+        main = ttk.Frame(self, padding=10)
+        main.pack(fill="both", expand=True)
+
+        left = ttk.Frame(main)
+        left.pack(side="left", fill="both", expand=True)
+        ttk.Label(left, text="Unassigned Samples:").pack(anchor="w")
+        self.file_list = tk.Listbox(left, selectmode="extended")
+        self.file_list.pack(fill="both", expand=True)
+        left_btns = ttk.Frame(left)
+        left_btns.pack(fill="x", pady=5)
+        ttk.Button(left_btns, text="Auto Group Prefix", command=self.auto_group).pack(side="left")
+        ttk.Button(left_btns, text="Add to Group →", command=self.add_selected).pack(side="right")
+
+        right = ttk.Frame(main)
+        right.pack(side="left", fill="both", expand=True, padx=(10,0))
+        top = ttk.Frame(right)
+        top.pack(fill="x")
+        ttk.Label(top, text="Groups:").pack(side="left")
+        self.group_combo = ttk.Combobox(top, textvariable=self.group_var, state="readonly")
+        self.group_combo.pack(side="left", fill="x", expand=True)
+        self.group_combo.bind("<<ComboboxSelected>>", self.refresh_group_files)
+        ttk.Button(top, text="Add Group", command=self.add_group).pack(side="left", padx=5)
+        ttk.Button(top, text="Remove Group", command=self.remove_group).pack(side="left")
+
+        ttk.Label(right, text="Files in Group:").pack(anchor="w", pady=(5,0))
+        self.group_list = tk.Listbox(right, selectmode="extended")
+        self.group_list.pack(fill="both", expand=True)
+        group_btns = ttk.Frame(right)
+        group_btns.pack(fill="x", pady=5)
+        ttk.Button(group_btns, text="← Remove", command=self.remove_selected).pack(side="left")
+
+        bottom = ttk.Frame(self, padding=10)
+        bottom.pack(fill="x")
+        ttk.Label(bottom, text="Key Mapping:").pack(side="left")
+        ttk.Combobox(bottom, textvariable=self.map_var, state="readonly", values=["all", "white", "black"]).pack(side="left")
+        ttk.Button(bottom, text="Build Instruments", command=self.build).pack(side="right")
+
+    def load_files(self):
+        folder = self.master.folder_path.get()
+        pattern = os.path.join(folder, '**', '*.wav') if self.master.recursive_scan_var.get() else os.path.join(folder, '*.wav')
+        files = glob.glob(pattern, recursive=self.master.recursive_scan_var.get())
+        self.unassigned = [os.path.relpath(f, folder) for f in files if '.xpm.wav' not in f.lower()]
+        self.refresh_file_list()
+
+    def refresh_file_list(self):
+        self.file_list.delete(0, tk.END)
+        for f in sorted(self.unassigned):
+            self.file_list.insert(tk.END, f)
+        self.refresh_group_combo()
+
+    def refresh_group_combo(self):
+        self.group_combo['values'] = list(self.groups.keys())
+        if self.group_var.get() not in self.groups and self.groups:
+            self.group_var.set(next(iter(self.groups)))
+        self.refresh_group_files()
+
+    def refresh_group_files(self, event=None):
+        self.group_list.delete(0, tk.END)
+        grp = self.group_var.get()
+        if grp in self.groups:
+            for f in self.groups[grp]:
+                self.group_list.insert(tk.END, f)
+
+    def add_group(self):
+        name = simpledialog.askstring("Group Name", "Enter group name:", parent=self)
+        if name and name not in self.groups:
+            self.groups[name] = []
+            self.group_var.set(name)
+            self.refresh_group_combo()
+
+    def remove_group(self):
+        grp = self.group_var.get()
+        if grp in self.groups:
+            self.unassigned.extend(self.groups.pop(grp))
+            self.group_var.set('')
+            self.refresh_file_list()
+
+    def add_selected(self):
+        grp = self.group_var.get()
+        if grp not in self.groups:
+            messagebox.showwarning("No Group", "Please select or create a group first.", parent=self)
+            return
+        indices = list(self.file_list.curselection())
+        for i in reversed(indices):
+            f = self.unassigned.pop(i)
+            self.groups[grp].append(f)
+        self.refresh_file_list()
+        self.refresh_group_files()
+
+    def remove_selected(self):
+        grp = self.group_var.get()
+        if grp not in self.groups:
+            return
+        indices = list(self.group_list.curselection())
+        for i in reversed(indices):
+            f = self.groups[grp].pop(i)
+            self.unassigned.append(f)
+        self.refresh_file_list()
+        self.refresh_group_files()
+
+    def auto_group(self):
+        for f in list(self.unassigned):
+            name = os.path.basename(f)[:5].upper()
+            self.groups.setdefault(name, []).append(f)
+            self.unassigned.remove(f)
+        self.refresh_file_list()
+
+    def generate_notes(self, count, mode):
+        notes, note = [], 60
+        while len(notes) < count and note < 128:
+            if mode == 'white' and note % 12 in [1,3,6,8,10]:
+                note += 1
+                continue
+            if mode == 'black' and note % 12 not in [1,3,6,8,10]:
+                note += 1
+                continue
+            notes.append(note)
+            note += 1
+        return notes
+
+    def build(self):
+        if not self.groups:
+            messagebox.showwarning("No Groups", "No groups defined.", parent=self)
+            return
+        options = self.options_cls(
+            loop_one_shots=self.master.loop_one_shots_var.get(),
+            analyze_scw=self.master.analyze_scw_var.get(),
+            creative_mode=self.master.creative_mode_var.get(),
+            recursive_scan=False,
+            firmware_version=self.master.firmware_version.get(),
+            polyphony=self.master.polyphony_var.get(),
+            creative_config=self.master.creative_config
+        )
+        builder = self.builder_cls(self.master.folder_path.get(), self.master, options)
+        mode = self.map_var.get()
+        for name, files in self.groups.items():
+            notes = self.generate_notes(len(files), mode)
+            builder._create_xpm(name, files, self.master.folder_path.get(), 'multi-sample', midi_notes=notes)
+        messagebox.showinfo("Done", "Instruments created.", parent=self)
+        self.destroy()


### PR DESCRIPTION
## Summary
- add a new `MultiSampleBuilderWindow` for grouping WAVs and assigning key ranges
- allow `_create_xpm` to accept explicit MIDI notes
- wire "Build Multi-Sampled Instruments" button to the new window

## Testing
- `python -m py_compile multi_sample_builder.py 'Gemini wav_TO_XpmV2.py'`
- `python 'Gemini wav_TO_XpmV2.py'` *(fails: This application requires a graphical display)*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e2288654832b84e9ebe336092cc0