### PR TITLE
Enhance multi‑sample builder and document keygroup types

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains tools for working with Akai MPC Keygroup programs.
 
+Additional documentation can be found in the `docs` folder, including a summary of the differences between drum and instrument keygroups.
+
 ## Scripts
 
 - `Gemini wav_TO_XpmV2.py` – main Tkinter GUI application for converting WAV files and managing expansions.

--- a/docs/drum_vs_instrument_keygroups.md
+++ b/docs/drum_vs_instrument_keygroups.md
@@ -1,0 +1,21 @@
+# Drum vs Instrument Keygroups
+
+This project generates `.xpm` keygroup programs for Akai MPC hardware and software. Keygroups fall into two main categories:
+
+## Drum Keygroups
+- Typically represent a drum kit where each sample is mapped to its own MIDI note/pad.
+- Root note equals the pad note and the usable range is restricted to that one note.
+- Often used for collections of single hits (kicks, snares, etc.) with minimal velocity layering.
+
+## Instrument Keygroups
+- Create a playable instrument across the keyboard.
+- Multiple samples are mapped to different root notes to cover a range of pitches.
+- Velocity layers can be used to trigger different samples at various dynamic levels.
+
+The `InstrumentBuilder` in the main application understands these modes via the `mode` argument:
+
+- `drum-kit` – builds a drum style keygroup with each sample assigned to consecutive MIDI notes.
+- `one-shot` – maps all provided samples to a single note for use as triggered FX or phrases.
+- `multi-sample` – spreads samples across the keyboard based on their detected root notes.
+
+Refer to `Gemini wav_TO_XpmV2.py` for the full implementation.

--- a/multi_sample_builder.py
+++ b/multi_sample_builder.py
@@ -21,6 +21,13 @@ class MultiSampleBuilderWindow(tk.Toplevel):
         self.load_files()
 
     def create_widgets(self):
+        path_frame = ttk.Frame(self, padding=(10, 5))
+        path_frame.pack(fill="x")
+        ttk.Label(path_frame, text="Source Folder:").pack(side="left")
+        self.folder_label = ttk.Label(path_frame, text=self.master.folder_path.get())
+        self.folder_label.pack(side="left", fill="x", expand=True)
+        ttk.Button(path_frame, text="Refresh", command=self.load_files).pack(side="right")
+
         main = ttk.Frame(self, padding=10)
         main.pack(fill="both", expand=True)
 
@@ -60,6 +67,8 @@ class MultiSampleBuilderWindow(tk.Toplevel):
 
     def load_files(self):
         folder = self.master.folder_path.get()
+        if hasattr(self, 'folder_label'):
+            self.folder_label.config(text=folder)
         pattern = os.path.join(folder, '**', '*.wav') if self.master.recursive_scan_var.get() else os.path.join(folder, '*.wav')
         files = glob.glob(pattern, recursive=self.master.recursive_scan_var.get())
         self.unassigned = [os.path.relpath(f, folder) for f in files if '.xpm.wav' not in f.lower()]


### PR DESCRIPTION
## Summary
- add docs describing drum vs instrument keygroups
- show selected folder in multi-sample builder with refresh option
- update README to reference documentation

## Testing
- `python -m py_compile "Gemini wav_TO_XpmV2.py" multi_sample_builder.py drumkit_grouping.py firmware_profiles.py batch_packager.py batch_program_editor.py`

------
https://chatgpt.com/codex/tasks/task_e_6867e7348c0c832b9beb6d972b56fa03