### PR TITLE
Improve logging and scanning

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -380,7 +380,7 @@ class ExpansionDoctorWindow(tk.Toplevel):
             try:
                 tree = ET.parse(xpm_path)
                 root = tree.getroot()
-            except ET.ParseError as e:
+            except Exception as e:
                 rel = os.path.relpath(xpm_path, folder)
                 logging.error(f"Error scanning {xpm_path}: {e}")
                 self.tree.insert(
@@ -393,9 +393,6 @@ class ExpansionDoctorWindow(tk.Toplevel):
                     'valid': False,
                     'missing': [],
                 }
-                continue
-            except Exception as e:
-                logging.error(f"Error scanning {xpm_path}: {e}")
                 continue
 
             missing = set()
@@ -978,6 +975,7 @@ class InstrumentBuilder:
         return True
 
     def create_instruments(self, mode='multi-sample'):
+        logging.info("create_instruments starting with mode %s", mode)
         if not self.validate_options():
             return
         created_xpms, created_count, error_count = [], 0, 0
@@ -1042,6 +1040,7 @@ class InstrumentBuilder:
             
     def _create_xpm(self, program_name, sample_files, output_folder, mode, midi_notes=None):
         """Creates a single XPM file from a group of samples using robust XML construction."""
+        logging.info("_create_xpm building '%s' with %d sample(s)", program_name, len(sample_files))
         try:
             sample_infos = []
             start_note = 60
@@ -1243,6 +1242,7 @@ class InstrumentBuilder:
 
     def process_previews_only(self):
         """Generates audio previews for all existing XPM files in the folder."""
+        logging.info("process_previews_only starting")
         self.app.status_text.set("Generating previews...")
         self.app.progress.config(mode='indeterminate')
         self.app.progress.start()
@@ -1379,7 +1379,9 @@ class App(tk.Tk):
         self.setup_logging()
 
     def setup_logging(self):
-        log_format = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+        log_format = logging.Formatter(
+            "%(asctime)s - %(levelname)s - %(funcName)s - %(message)s"
+        )
         text_handler = TextHandler(self.log_text)
         text_handler.setFormatter(log_format)
         root_logger = logging.getLogger()

--- a/multi_sample_builder.py
+++ b/multi_sample_builder.py
@@ -1,5 +1,6 @@
 import os
 import glob
+import logging
 import tkinter as tk
 from tkinter import ttk, messagebox, simpledialog
 
@@ -155,6 +156,7 @@ class MultiSampleBuilderWindow(tk.Toplevel):
         if not self.groups:
             messagebox.showwarning("No Groups", "No groups defined.", parent=self)
             return
+        logging.info("MultiSampleBuilderWindow.build starting")
         options = self.options_cls(
             loop_one_shots=self.master.loop_one_shots_var.get(),
             analyze_scw=self.master.analyze_scw_var.get(),
@@ -167,6 +169,7 @@ class MultiSampleBuilderWindow(tk.Toplevel):
         builder = self.builder_cls(self.master.folder_path.get(), self.master, options)
         mode = self.map_var.get()
         for name, files in self.groups.items():
+            logging.info("Building group '%s' with %d file(s)", name, len(files))
             notes = self.generate_notes(len(files), mode)
             builder._create_xpm(name, files, self.master.folder_path.get(), 'multi-sample', midi_notes=notes)
         messagebox.showinfo("Done", "Instruments created.", parent=self)


### PR DESCRIPTION
## Summary
- include function name in log format
- better error handling when scanning XPM files
- add log statements for multi-sample builder and builder functions

## Testing
- `python -m py_compile "Gemini wav_TO_XpmV2.py" multi_sample_builder.py`

------
https://chatgpt.com/codex/tasks/task_e_6867eea302f4832b8340c8f78bb2ad37