### PR TITLE
Fix variable in Merge Subfolders tool

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -936,7 +936,10 @@ class MergeSubfoldersWindow(tk.Toplevel):
         self.geometry("400x220")
         self.master = master
         self.target_depth = tk.IntVar(value=0)
-        self.max_depth = tk.IntVar(value=2)
+        # IntVar used to control how deep subfolders are scanned when merging
+        # files. Renamed variable to avoid confusion with the `max_depth`
+        # argument in the merge functions below.
+        self.max_depth_var = tk.IntVar(value=2)
         self.create_widgets()
 
     def create_widgets(self):
@@ -951,7 +954,7 @@ class MergeSubfoldersWindow(tk.Toplevel):
         opt_frame = ttk.Frame(frame)
         opt_frame.pack(anchor="w", pady=(10,0))
         ttk.Label(opt_frame, text="Max depth to scan:").pack(side="left")
-        ttk.Spinbox(opt_frame, from_=1, to=10, textvariable=self.max_depth, width=4).pack(side="left")
+        ttk.Spinbox(opt_frame, from_=1, to=10, textvariable=self.max_depth_var, width=4).pack(side="left")
 
         btn_frame = ttk.Frame(frame)
         btn_frame.pack(fill="x", pady=(20,0))
@@ -960,7 +963,7 @@ class MergeSubfoldersWindow(tk.Toplevel):
 
     def apply_merge(self):
         depth = self.target_depth.get()
-        max_depth = self.max_depth.get()
+        max_depth = self.max_depth_var.get()
         self.destroy()
         self.master.run_batch_process(
             merge_subfolders,


### PR DESCRIPTION
## Summary
- fix the variable used for the maximum merge depth in `MergeSubfoldersWindow`
- update references to the renamed variable

## Testing
- `python -m py_compile Gemini\ wav_TO_XpmV2.py`
- `python -m py_compile batch_packager.py batch_program_editor.py drumkit_grouping.py firmware_profiles.py multi_sample_builder.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68692073cda8832b8bf19971b0344a78