### PR TITLE
Enhance batch fixer with firmware/format options

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Additional documentation can be found in the [docs/](docs/) directory, including
 - `batch_program_editor.py` – batch editor for `.xpm` program files allowing rename and firmware version changes.
   This functionality is also accessible from the GUI via **Batch Program Editor...** under Advanced Tools.
 
+### New in this update
+- Batch Program Fixer rebuild option now includes firmware and format selectors. You
+  can rebuild programs into legacy (v2) or advanced (v3) formats while preserving
+  all sample layers.
+
 ## Recent Changes
 - Build Instruments window now lists `.wav` files regardless of case so samples with `.WAV` extensions appear correctly.
 - Expansion Doctor displays invalid or corrupt `.xpm` files instead of skipping them.

--- a/firmware_profiles.py
+++ b/firmware_profiles.py
@@ -95,9 +95,18 @@ LEGACY_REMOVE_KEYS = {
     '2.6.0.17': ['KeygroupWheelToLfo2', 'KeygroupAftertouchToFilter2'],
 }
 
-def get_pad_settings(firmware: str):
-    """Return pad settings dict for a firmware version."""
-    return PAD_SETTINGS.get(firmware, PAD_SETTINGS['3.5.0'])
+def get_pad_settings(firmware: str, engine_override: str | None = None):
+    """Return pad settings dict for a firmware version.
+
+    The optional ``engine_override`` parameter allows callers to force
+    the ``engine`` value regardless of the firmware's default. This is
+    used when rebuilding programs where the user wants to explicitly
+    choose between legacy (v2) and advanced (v3) formats.
+    """
+    settings = PAD_SETTINGS.get(firmware, PAD_SETTINGS['3.5.0']).copy()
+    if engine_override in {'legacy', 'advanced'}:
+        settings['engine'] = engine_override
+    return settings
 
 
 def get_program_parameters(firmware: str, num_keygroups: int) -> dict:


### PR DESCRIPTION
## Summary
- allow overriding pad engine in `get_pad_settings`
- track velocity ranges when parsing XPMs
- add `format_version` to InstrumentOptions and rebuild logic
- support rebuilding using mappings to preserve layers
- expose firmware/format selectors in Batch Program Fixer
- document new feature

## Testing
- `python -m py_compile Gemini\ wav_TO_XpmV2.py firmware_profiles.py batch_packager.py batch_program_editor.py multi_sample_builder.py drumkit_grouping.py xpm_parameter_editor.py`


------
https://chatgpt.com/codex/tasks/task_e_686ab0c34660832bac90f928a6d45dba