### PR TITLE
Ignore macOS resource files during batch editing

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -2334,7 +2334,7 @@ def batch_edit_programs(
     matrix = load_mod_matrix(mod_matrix_file) if mod_matrix_file else None
     for root_dir, _dirs, files in os.walk(folder_path):
         for file in files:
-            if not file.lower().endswith('.xpm'):
+            if not file.lower().endswith('.xpm') or file.startswith('._'):
                 continue
             path = os.path.join(root_dir, file)
             try:

--- a/batch_program_editor.py
+++ b/batch_program_editor.py
@@ -70,22 +70,23 @@ def process_folder(
 ):
     for root_dir, _dirs, files in os.walk(folder):
         for file in files:
-            if file.lower().endswith('.xpm'):
-                path = os.path.join(root_dir, file)
-                try:
-                    edit_program(
-                        path,
-                        rename,
-                        version,
-                        keytrack,
-                        attack,
-                        decay,
-                        sustain,
-                        release,
-                        mod_matrix,
-                    )
-                except Exception as exc:
-                    logging.error("Failed to edit %s: %s", path, exc)
+            if file.startswith('._') or not file.lower().endswith('.xpm'):
+                continue
+            path = os.path.join(root_dir, file)
+            try:
+                edit_program(
+                    path,
+                    rename,
+                    version,
+                    keytrack,
+                    attack,
+                    decay,
+                    sustain,
+                    release,
+                    mod_matrix,
+                )
+            except Exception as exc:
+                logging.error("Failed to edit %s: %s", path, exc)
 
 
 def main():


### PR DESCRIPTION
## Summary
- skip `._` resource forks when editing XPM files

## Testing
- `python -m py_compile batch_program_editor.py "Gemini wav_TO_XpmV2.py"`

------
https://chatgpt.com/codex/tasks/task_e_686eb93fffb4832b983db14386fab521