### PR TITLE
Improve folder grouping and build options

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ Additional documentation can be found in the [docs/](docs/) directory, including
 ## Recent Changes
 - Build Instruments window now lists `.wav` files regardless of case so samples with `.WAV` extensions appear correctly.
 - Expansion Doctor displays invalid or corrupt `.xpm` files instead of skipping them.
+- Auto Group Folders now previews folder names with sample counts before grouping.
+- Multi-sample builder prompts for Drum Program or Instrument Keygroup when building.


### PR DESCRIPTION
## Summary
- preview subfolders and counts before grouping them in MultiSample Builder
- prompt for Drum Program or Instrument Keygroup when building
- document the new preview and build options

## Testing
- `python -m py_compile multi_sample_builder.py`
- `python -m py_compile 'Gemini wav_TO_XpmV2.py'`

------
https://chatgpt.com/codex/tasks/task_e_686ec82515c0832b9d6f56821f1ea693