### PR TITLE
Fix advanced/legacy program parameter selection

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -1645,7 +1645,11 @@ class InstrumentBuilder:
     def get_program_parameters(self, num_keygroups):
         if not IMPORTS_SUCCESSFUL: return {}
         firmware = self.options.firmware_version
-        return fw_program_parameters(firmware, num_keygroups)
+        return fw_program_parameters(
+            firmware,
+            num_keygroups,
+            engine_override=self.options.format_version,
+        )
 
     def build_instrument_element(self, parent, num, low, high):
         instrument = ET.SubElement(parent, 'Instrument', {'number': str(num)})

--- a/firmware_profiles.py
+++ b/firmware_profiles.py
@@ -109,14 +109,21 @@ def get_pad_settings(firmware: str, engine_override: str | None = None):
     return settings
 
 
-def get_program_parameters(firmware: str, num_keygroups: int) -> dict:
-    """Return program parameter dictionary customized per firmware."""
+def get_program_parameters(
+    firmware: str, num_keygroups: int, engine_override: str | None = None
+) -> dict:
+    """Return program parameter dictionary customized per firmware and engine."""
     engine = PAD_SETTINGS.get(firmware, PAD_SETTINGS['3.5.0']).get('engine')
+    if engine_override in {'legacy', 'advanced'}:
+        engine = engine_override
+
     if engine == 'advanced' and ADVANCED_PROGRAM_PARAMS:
         params = ADVANCED_PROGRAM_PARAMS.copy()
     else:
         params = DEFAULT_PROGRAM_PARAMS.copy()
+
     params['KeygroupNumKeygroups'] = str(num_keygroups)
     for key in LEGACY_REMOVE_KEYS.get(firmware, []):
         params.pop(key, None)
+
     return params


### PR DESCRIPTION
## Summary
- support engine override in get_program_parameters
- use InstrumentOptions.format_version to select parameters for each firmware

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_686ed071038c832b8987d87c85c689f3