### PR TITLE
Improve mod matrix error handling

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -2336,6 +2336,8 @@ def batch_edit_programs(
                                creative_config=creative_config or {})
     builder = InstrumentBuilder(folder_path, None, options)
     matrix = load_mod_matrix(mod_matrix_file) if mod_matrix_file else None
+    if matrix == {}:
+        matrix = None
     for root_dir, _dirs, files in os.walk(folder_path):
         for file in files:
             if not file.lower().endswith('.xpm') or file.startswith('._'):

--- a/xpm_parameter_editor.py
+++ b/xpm_parameter_editor.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import xml.etree.ElementTree as ET
 from typing import Optional, Dict
 
@@ -42,8 +43,13 @@ def set_volume_adsr(root: ET.Element,
 
 def load_mod_matrix(path: str) -> Dict[int, Dict[str, str]]:
     """Load a mod matrix JSON file into a dictionary."""
-    with open(path, 'r', encoding='utf-8') as f:
-        data = json.load(f)
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logging.error("Could not load mod matrix '%s': %s", path, e)
+        return {}
+
     matrix: Dict[int, Dict[str, str]] = {}
     if isinstance(data, list):
         for entry in data:


### PR DESCRIPTION
## Summary
- add logging in `load_mod_matrix` and return an empty dict when loading fails
- skip applying the mod matrix in `batch_edit_programs` when no matrix data is loaded

## Testing
- `python -m py_compile "Gemini wav_TO_XpmV2.py" xpm_parameter_editor.py batch_program_editor.py batch_packager.py multi_sample_builder.py drumkit_grouping.py firmware_profiles.py`

------
https://chatgpt.com/codex/tasks/task_e_686ed66adb24832b9bf2d491d1733996