### PR TITLE
Fix mod matrix crash in batch editor

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -1007,6 +1007,7 @@ class BatchProgramEditorWindow(tk.Toplevel):
             batch_edit_programs,
             self.rename_var.get(),
             self.version_var.get().strip() or None,
+            None,
             self.creative_var.get(),
             self.master.creative_config,
             self.keytrack_var.get() == "on",


### PR DESCRIPTION
## Summary
- fix argument order when calling `batch_edit_programs`

## Testing
- `python -m py_compile 'Gemini wav_TO_XpmV2.py'`


------
https://chatgpt.com/codex/tasks/task_e_686eec02a05c832b8a9cb47684cadaea