### PR TITLE
Add format option for batch program editing

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -904,8 +904,9 @@ class BatchProgramEditorWindow(tk.Toplevel):
         super().__init__(master.root)
         self.master = master
         self.title("Batch Program Editor")
-        self.geometry("400x360")
+        self.geometry("400x390")
         self.resizable(False, False)
+        self.format_var = tk.StringVar(value="advanced")
         self.create_widgets()
 
     def create_widgets(self):
@@ -921,23 +922,26 @@ class BatchProgramEditorWindow(tk.Toplevel):
         versions = ['2.3.0.0','2.6.0.17','3.4.0','3.5.0']
         ttk.Combobox(frame, textvariable=self.version_var, values=versions, state="readonly").grid(row=1, column=1, sticky="ew", pady=(10,0))
 
-        ttk.Label(frame, text="Creative Mode:").grid(row=2, column=0, sticky="w", pady=(10,0))
+        ttk.Label(frame, text="Format:").grid(row=2, column=0, sticky="w", pady=(10,0))
+        ttk.Combobox(frame, textvariable=self.format_var, values=['legacy','advanced'], state="readonly").grid(row=2, column=1, sticky="ew", pady=(10,0))
+
+        ttk.Label(frame, text="Creative Mode:").grid(row=3, column=0, sticky="w", pady=(10,0))
         self.creative_var = tk.StringVar(value="off")
         modes = ['off', 'subtle', 'synth', 'lofi', 'reverse', 'stereo_spread']
         self.creative_combo = ttk.Combobox(frame, textvariable=self.creative_var, values=modes, state="readonly")
-        self.creative_combo.grid(row=2, column=1, sticky="ew", pady=(10,0))
+        self.creative_combo.grid(row=3, column=1, sticky="ew", pady=(10,0))
         self.creative_combo.bind("<<ComboboxSelected>>", self.toggle_config_btn)
 
         self.config_btn = ttk.Button(frame, text="Configure...", command=self.open_config, state='disabled')
-        self.config_btn.grid(row=3, column=1, sticky="e")
+        self.config_btn.grid(row=4, column=1, sticky="e")
 
-        ttk.Label(frame, text="KeyTrack:").grid(row=4, column=0, sticky="w", pady=(10,0))
+        ttk.Label(frame, text="KeyTrack:").grid(row=5, column=0, sticky="w", pady=(10,0))
         self.keytrack_var = tk.StringVar(value="on")
-        ttk.Combobox(frame, textvariable=self.keytrack_var, values=["on","off"], state="readonly").grid(row=4, column=1, sticky="ew", pady=(10,0))
+        ttk.Combobox(frame, textvariable=self.keytrack_var, values=["on","off"], state="readonly").grid(row=5, column=1, sticky="ew", pady=(10,0))
 
-        ttk.Label(frame, text="Volume ADSR:").grid(row=5, column=0, sticky="w", pady=(10,0))
+        ttk.Label(frame, text="Volume ADSR:").grid(row=6, column=0, sticky="w", pady=(10,0))
         adsr = ttk.Frame(frame)
-        adsr.grid(row=5, column=1, sticky="ew", pady=(10,0))
+        adsr.grid(row=6, column=1, sticky="ew", pady=(10,0))
         self.attack_var = tk.StringVar()
         self.decay_var = tk.StringVar()
         self.sustain_var = tk.StringVar()
@@ -947,16 +951,16 @@ class BatchProgramEditorWindow(tk.Toplevel):
         ttk.Entry(adsr, width=4, textvariable=self.sustain_var).pack(side="left")
         ttk.Entry(adsr, width=4, textvariable=self.release_var).pack(side="left", padx=2)
 
-        ttk.Label(frame, text="Mod Matrix File:").grid(row=6, column=0, sticky="w", pady=(10,0))
+        ttk.Label(frame, text="Mod Matrix File:").grid(row=7, column=0, sticky="w", pady=(10,0))
         self.mod_matrix_var = tk.StringVar()
         mm_frame = ttk.Frame(frame)
-        mm_frame.grid(row=6, column=1, sticky="ew", pady=(10,0))
+        mm_frame.grid(row=7, column=1, sticky="ew", pady=(10,0))
         mm_frame.columnconfigure(0, weight=1)
         ttk.Entry(mm_frame, textvariable=self.mod_matrix_var).grid(row=0, column=0, sticky="ew")
         ttk.Button(mm_frame, text="Browse...", command=self.browse_mod_matrix).grid(row=0, column=1, padx=(5,0))
 
         btn_frame = ttk.Frame(frame)
-        btn_frame.grid(row=7, column=0, columnspan=2, pady=(15,0), sticky="e")
+        btn_frame.grid(row=8, column=0, columnspan=2, pady=(15,0), sticky="e")
         ttk.Button(btn_frame, text="Apply", command=self.apply_edits).pack(side="right")
         ttk.Button(btn_frame, text="Close", command=self.destroy).pack(side="right", padx=(5,0))
 
@@ -1007,7 +1011,7 @@ class BatchProgramEditorWindow(tk.Toplevel):
             batch_edit_programs,
             self.rename_var.get(),
             self.version_var.get().strip() or None,
-            None,
+            self.format_var.get().strip() or None,
             self.creative_var.get(),
             self.master.creative_config,
             self.keytrack_var.get() == "on",
@@ -2388,8 +2392,11 @@ def batch_edit_programs(
         logging.error("Cannot run batch edit, required modules are missing.")
         return 0
 
-    options = InstrumentOptions(creative_mode=creative_mode,
-                               creative_config=creative_config or {})
+    options = InstrumentOptions(
+        creative_mode=creative_mode,
+        creative_config=creative_config or {},
+        format_version=format_version if format_version else 'advanced'
+    )
     builder = InstrumentBuilder(folder_path, None, options)
     matrix = load_mod_matrix(mod_matrix_file) if mod_matrix_file else None
     if matrix == {}:

--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ Additional documentation can be found in the [docs/](docs/) directory, including
 
 - `Gemini wav_TO_XpmV2.py` – main Tkinter GUI application for converting WAV files and managing expansions. This filename supersedes the earlier `wav_to_xpm_converter_v22.py`.
 - `batch_packager.py` – command-line tool to package each subfolder of a directory into its own expansion ZIP.
-- `batch_program_editor.py` – batch editor for `.xpm` program files allowing rename and firmware version changes.
+- `batch_program_editor.py` – batch editor for `.xpm` program files allowing rename, firmware, and format changes.
   This functionality is also accessible from the GUI via **Batch Program Editor...** under Advanced Tools.
-  The editor now provides a drop-down list of common **Application Version** values
-  and a **Browse...** button for selecting a Mod Matrix JSON file. The matrix file
-  should be a `.json` list where each entry contains a `Num` value and the desired
-  parameters for that modulation slot.
+  The editor now provides drop-down selectors for **Application Version** and **Format**
+  (legacy or advanced) plus a **Browse...** button for selecting a Mod Matrix JSON file.
+  The matrix file should be a `.json` list where each entry contains a `Num` value
+  and the desired parameters for that modulation slot.
+  When using the command-line tool you can pass `--format legacy` or `--format advanced`
+  to produce programs in either layout.
 
 ### New in this update
 - Batch Program Fixer rebuild option now includes firmware and format selectors. You


### PR DESCRIPTION
## Summary
- allow `batch_edit_programs` to control target engine format
- surface a Format selector in Batch Program Editor and forward the choice
- mention the new option for GUI and CLI in README

## Testing
- `python -m py_compile "Gemini wav_TO_XpmV2.py" "batch_program_editor.py"`
- `python batch_program_editor.py --help | head`

------
https://chatgpt.com/codex/tasks/task_e_686efe38f5a0832ba6e18eb90ed61b25