### PR TITLE
Add indent_tree helper to batch editor

### DIFF
--- a/batch_program_editor.py
+++ b/batch_program_editor.py
@@ -2,6 +2,26 @@ import os
 import argparse
 import logging
 import xml.etree.ElementTree as ET
+
+def indent_tree(tree: ET.ElementTree, space: str = "  ") -> None:
+    """Indent an ElementTree for pretty printing."""
+    if hasattr(ET, "indent"):
+        ET.indent(tree, space=space)
+    else:
+        def _indent(elem: ET.Element, level: int = 0) -> None:
+            i = "\n" + level * space
+            if len(elem):
+                if not elem.text or not elem.text.strip():
+                    elem.text = i + space
+                for child in elem:
+                    _indent(child, level + 1)
+                if not child.tail or not child.tail.strip():  # type: ignore
+                    child.tail = i  # type: ignore
+            if level and (not elem.tail or not elem.tail.strip()):
+                elem.tail = i
+
+        _indent(tree.getroot())
+
 from xpm_parameter_editor import (
     set_layer_keytrack,
     set_volume_adsr,
@@ -57,7 +77,7 @@ def edit_program(
             changed = True
 
     if changed:
-        ET.indent(tree, space="  ")
+        indent_tree(tree)
         tree.write(file_path, encoding='utf-8', xml_declaration=True)
         logging.info("Updated %s", file_path)
 


### PR DESCRIPTION
## Summary
- support consistent XML indentation across Python versions
- replace direct `ET.indent` call with new `indent_tree` wrapper

## Testing
- `python -m py_compile "Gemini wav_TO_XpmV2.py" batch_packager.py batch_program_editor.py drumkit_grouping.py firmware_profiles.py multi_sample_builder.py xpm_parameter_editor.py`

------
https://chatgpt.com/codex/tasks/task_e_686f0388b570832b9545cab97ccc5f95