### PR TITLE
Fix bool attribute error in batch edit

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -29,6 +29,7 @@ try:
         apply_mod_matrix,
         set_engine_mode,
         set_application_version,
+        fix_sample_notes,
     )
     from drumkit_grouping import group_similar_files
     from multi_sample_builder import MultiSampleBuilderWindow
@@ -921,23 +922,27 @@ class BatchProgramEditorWindow(tk.Toplevel):
         versions = ['2.3.0.0','2.6.0.17','3.4.0','3.5.0']
         ttk.Combobox(frame, textvariable=self.version_var, values=versions, state="readonly").grid(row=1, column=1, sticky="ew", pady=(10,0))
 
-        ttk.Label(frame, text="Creative Mode:").grid(row=2, column=0, sticky="w", pady=(10,0))
+        ttk.Label(frame, text="Format:").grid(row=2, column=0, sticky="w", pady=(10,0))
+        self.format_var = tk.StringVar(value="advanced")
+        ttk.Combobox(frame, textvariable=self.format_var, values=["legacy","advanced"], state="readonly").grid(row=2, column=1, sticky="ew", pady=(10,0))
+
+        ttk.Label(frame, text="Creative Mode:").grid(row=3, column=0, sticky="w", pady=(10,0))
         self.creative_var = tk.StringVar(value="off")
         modes = ['off', 'subtle', 'synth', 'lofi', 'reverse', 'stereo_spread']
         self.creative_combo = ttk.Combobox(frame, textvariable=self.creative_var, values=modes, state="readonly")
-        self.creative_combo.grid(row=2, column=1, sticky="ew", pady=(10,0))
+        self.creative_combo.grid(row=3, column=1, sticky="ew", pady=(10,0))
         self.creative_combo.bind("<<ComboboxSelected>>", self.toggle_config_btn)
 
         self.config_btn = ttk.Button(frame, text="Configure...", command=self.open_config, state='disabled')
-        self.config_btn.grid(row=3, column=1, sticky="e")
+        self.config_btn.grid(row=4, column=1, sticky="e")
 
-        ttk.Label(frame, text="KeyTrack:").grid(row=4, column=0, sticky="w", pady=(10,0))
+        ttk.Label(frame, text="KeyTrack:").grid(row=5, column=0, sticky="w", pady=(10,0))
         self.keytrack_var = tk.StringVar(value="on")
-        ttk.Combobox(frame, textvariable=self.keytrack_var, values=["on","off"], state="readonly").grid(row=4, column=1, sticky="ew", pady=(10,0))
+        ttk.Combobox(frame, textvariable=self.keytrack_var, values=["on","off"], state="readonly").grid(row=5, column=1, sticky="ew", pady=(10,0))
 
-        ttk.Label(frame, text="Volume ADSR:").grid(row=5, column=0, sticky="w", pady=(10,0))
+        ttk.Label(frame, text="Volume ADSR:").grid(row=6, column=0, sticky="w", pady=(10,0))
         adsr = ttk.Frame(frame)
-        adsr.grid(row=5, column=1, sticky="ew", pady=(10,0))
+        adsr.grid(row=6, column=1, sticky="ew", pady=(10,0))
         self.attack_var = tk.StringVar()
         self.decay_var = tk.StringVar()
         self.sustain_var = tk.StringVar()
@@ -947,16 +952,19 @@ class BatchProgramEditorWindow(tk.Toplevel):
         ttk.Entry(adsr, width=4, textvariable=self.sustain_var).pack(side="left")
         ttk.Entry(adsr, width=4, textvariable=self.release_var).pack(side="left", padx=2)
 
-        ttk.Label(frame, text="Mod Matrix File:").grid(row=6, column=0, sticky="w", pady=(10,0))
+        ttk.Label(frame, text="Mod Matrix File:").grid(row=7, column=0, sticky="w", pady=(10,0))
         self.mod_matrix_var = tk.StringVar()
         mm_frame = ttk.Frame(frame)
-        mm_frame.grid(row=6, column=1, sticky="ew", pady=(10,0))
+        mm_frame.grid(row=7, column=1, sticky="ew", pady=(10,0))
         mm_frame.columnconfigure(0, weight=1)
         ttk.Entry(mm_frame, textvariable=self.mod_matrix_var).grid(row=0, column=0, sticky="ew")
         ttk.Button(mm_frame, text="Browse...", command=self.browse_mod_matrix).grid(row=0, column=1, padx=(5,0))
 
+        self.fix_notes_var = tk.BooleanVar()
+        ttk.Checkbutton(frame, text="Fix sample notes", variable=self.fix_notes_var).grid(row=8, column=0, columnspan=2, sticky="w", pady=(10,0))
+
         btn_frame = ttk.Frame(frame)
-        btn_frame.grid(row=7, column=0, columnspan=2, pady=(15,0), sticky="e")
+        btn_frame.grid(row=9, column=0, columnspan=2, pady=(15,0), sticky="e")
         ttk.Button(btn_frame, text="Apply", command=self.apply_edits).pack(side="right")
         ttk.Button(btn_frame, text="Close", command=self.destroy).pack(side="right", padx=(5,0))
 
@@ -1007,6 +1015,7 @@ class BatchProgramEditorWindow(tk.Toplevel):
             batch_edit_programs,
             self.rename_var.get(),
             self.version_var.get().strip() or None,
+            self.format_var.get(),
             self.creative_var.get(),
             self.master.creative_config,
             self.keytrack_var.get() == "on",
@@ -1015,6 +1024,7 @@ class BatchProgramEditorWindow(tk.Toplevel):
             sustain,
             release,
             self.mod_matrix_var.get().strip() or None,
+            self.fix_notes_var.get(),
         )
         self.destroy()
 
@@ -2380,6 +2390,7 @@ def batch_edit_programs(
     sustain=None,
     release=None,
     mod_matrix_file=None,
+    fix_notes=False,
 ):
     """Batch edit XPM files with optional renaming, version, and engine updates."""
     edited = 0
@@ -2439,6 +2450,10 @@ def batch_edit_programs(
 
                 if matrix:
                     if apply_mod_matrix(root, matrix):
+                        changed = True
+
+                if fix_notes:
+                    if fix_sample_notes(root, os.path.dirname(path)):
                         changed = True
 
                 if changed:

--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ Additional documentation can be found in the [docs/](docs/) directory, including
 
 - `Gemini wav_TO_XpmV2.py` – main Tkinter GUI application for converting WAV files and managing expansions.
 - `batch_packager.py` – command-line tool to package each subfolder of a directory into its own expansion ZIP.
-- `batch_program_editor.py` – batch editor for `.xpm` program files allowing rename and firmware version changes.
+- `batch_program_editor.py` – batch editor for `.xpm` program files allowing rename, firmware version, and format changes.
   This functionality is also accessible from the GUI via **Batch Program Editor...** under Advanced Tools.
-  The editor now provides a drop-down list of common **Application Version** values
-  and a **Browse...** button for selecting a Mod Matrix JSON file. The matrix file
-  should be a `.json` list where each entry contains a `Num` value and the desired
-  parameters for that modulation slot.
+  The editor includes drop-downs for **Application Version** and engine **Format**, a
+  checkbox for fixing sample note mappings, and a **Browse...** button for selecting a Mod Matrix JSON file.
+  The matrix file should be a `.json` list where each entry contains a `Num` value and the desired
+  parameters for that modulation slot. The command-line version exposes the same options via
+  `--format`, `--mod-matrix`, and the new `--fix-notes` flag for repairing sample note assignments.
 
 ### New in this update
 - Batch Program Fixer rebuild option now includes firmware and format selectors. You

--- a/batch_program_editor.py
+++ b/batch_program_editor.py
@@ -9,6 +9,7 @@ from xpm_parameter_editor import (
     apply_mod_matrix,
     set_engine_mode,
     set_application_version,
+    fix_sample_notes,
 )
 
 
@@ -23,6 +24,7 @@ def edit_program(
     sustain: float | None,
     release: float | None,
     mod_matrix: dict | None,
+    fix_notes: bool = False,
 ):
     """Edit a single XPM program in-place."""
     tree = ET.parse(file_path)
@@ -56,6 +58,10 @@ def edit_program(
         if apply_mod_matrix(root, mod_matrix):
             changed = True
 
+    if fix_notes:
+        if fix_sample_notes(root, os.path.dirname(file_path)):
+            changed = True
+
     if changed:
         ET.indent(tree, space="  ")
         tree.write(file_path, encoding='utf-8', xml_declaration=True)
@@ -73,6 +79,7 @@ def process_folder(
     sustain: float | None,
     release: float | None,
     mod_matrix: dict | None,
+    fix_notes: bool = False,
 ):
     for root_dir, _dirs, files in os.walk(folder):
         for file in files:
@@ -91,6 +98,7 @@ def process_folder(
                     sustain,
                     release,
                     mod_matrix,
+                    fix_notes,
                 )
             except Exception as exc:
                 logging.error("Failed to edit %s: %s", path, exc)
@@ -108,6 +116,7 @@ def main():
     parser.add_argument("--sustain", type=float, help="Set VolumeSustain value")
     parser.add_argument("--release", type=float, help="Set VolumeRelease value")
     parser.add_argument("--mod-matrix", dest="mod_matrix", help="JSON file with ModLink definitions")
+    parser.add_argument("--fix-notes", action="store_true", help="Adjust note mappings using sample names")
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
     args = parser.parse_args()
 
@@ -119,6 +128,7 @@ def main():
         keytrack = args.keytrack == "on"
     mod_matrix = load_mod_matrix(args.mod_matrix) if args.mod_matrix else None
     fmt = args.format if args.format else None
+    fix_notes = args.fix_notes
 
     process_folder(
         args.folder,
@@ -131,6 +141,7 @@ def main():
         args.sustain,
         args.release,
         mod_matrix,
+        fix_notes,
     )
 
 

--- a/xpm_parameter_editor.py
+++ b/xpm_parameter_editor.py
@@ -4,6 +4,9 @@ import xml.etree.ElementTree as ET
 from typing import Optional, Dict
 from xml.sax.saxutils import escape as xml_escape, unescape as xml_unescape
 
+import os
+import re
+import struct
 
 def _update_text(elem: Optional[ET.Element], value: Optional[str]) -> bool:
     if elem is None or value is None:
@@ -100,6 +103,8 @@ def set_engine_mode(root: ET.Element, mode: str) -> bool:
             data = json.loads(xml_unescape(pads_elem.text))
         except json.JSONDecodeError:
             data = {}
+        if not isinstance(data, dict):
+            data = {}
         if data.get('engine') != mode:
             data['engine'] = mode
             pads_elem.text = xml_escape(json.dumps(data, indent=4))
@@ -111,4 +116,108 @@ def set_engine_mode(root: ET.Element, mode: str) -> bool:
     else:
         changed |= _update_text(legacy_elem, 'False')
 
+    return changed
+
+def name_to_midi(note_name: str) -> int | None:
+    """Convert note name like C#4 to MIDI note number."""
+    if not note_name:
+        return None
+    note_map = {'C':0,'C#':1,'DB':1,'D':2,'D#':3,'EB':3,'E':4,'F':5,'F#':6,'GB':6,'G':7,'G#':8,'AB':8,'A':9,'A#':10,'BB':10,'B':11}
+    m = re.match(r'^([A-G][#B]?)(-?\d+)$', note_name.strip().upper())
+    if not m:
+        return None
+    note, octave = m.groups()
+    if note not in note_map:
+        return None
+    try:
+        midi = 12 + note_map[note] + 12 * int(octave)
+        return midi if 0 <= midi <= 127 else None
+    except (TypeError, ValueError):
+        return None
+
+
+def infer_note_from_filename(filename: str) -> int | None:
+    """Infer MIDI note from file name if it contains note or number."""
+    base = os.path.splitext(os.path.basename(filename))[0]
+    m = re.search(r'[ _-]?([A-G][#b]?\-?\d+)', base, re.IGNORECASE)
+    if m:
+        midi = name_to_midi(m.group(1))
+        if midi is not None:
+            return midi
+    m = re.search(r'\b(\d{2,3})\b', base)
+    if m:
+        num = int(m.group(1))
+        if 0 <= num <= 127:
+            return num
+    return None
+
+
+def extract_root_note_from_wav(filepath: str) -> int | None:
+    """Read MIDI root note from WAV smpl chunk."""
+    try:
+        with open(filepath, 'rb') as f:
+            data = f.read()
+        idx = data.find(b'smpl')
+        if idx != -1 and idx + 36 <= len(data):
+            note = struct.unpack('<I', data[idx+28:idx+32])[0]
+            if 0 <= note <= 127:
+                return note
+    except Exception as e:
+        logging.error("Could not extract root note from WAV %s: %s", filepath, e)
+    return None
+
+
+def fix_sample_notes(root: ET.Element, folder: str) -> bool:
+    """Update sample note mappings using file names or WAV metadata."""
+    changed = False
+    pads_elem = root.find('.//ProgramPads-v2.10') or root.find('.//ProgramPads')
+    if pads_elem is not None and pads_elem.text:
+        try:
+            data = json.loads(xml_unescape(pads_elem.text))
+        except json.JSONDecodeError:
+            data = {}
+        if not isinstance(data, dict):
+            data = {}
+        pads = data.get('pads', {})
+        for pad in pads.values():
+            if isinstance(pad, dict) and pad.get('samplePath'):
+                sample_path = pad['samplePath']
+                abs_path = sample_path if os.path.isabs(sample_path) else os.path.join(folder, sample_path)
+                midi = extract_root_note_from_wav(abs_path) or infer_note_from_filename(sample_path)
+                if midi is None:
+                    continue
+                if pad.get('rootNote') != midi:
+                    pad['rootNote'] = midi
+                    changed = True
+                if pad.get('lowNote') != midi:
+                    pad['lowNote'] = midi
+                    changed = True
+                if pad.get('highNote') != midi:
+                    pad['highNote'] = midi
+                    changed = True
+        if changed:
+            pads_elem.text = xml_escape(json.dumps(data, indent=4))
+
+    for inst in root.findall('.//Instrument'):
+        low_elem = inst.find('LowNote')
+        high_elem = inst.find('HighNote')
+        for layer in inst.findall('.//Layer'):
+            sample_elem = layer.find('SampleFile')
+            root_elem = layer.find('RootNote')
+            if sample_elem is None or not sample_elem.text:
+                continue
+            sample_path = sample_elem.text
+            abs_path = sample_path if os.path.isabs(sample_path) else os.path.join(folder, sample_path)
+            midi = extract_root_note_from_wav(abs_path) or infer_note_from_filename(sample_path)
+            if midi is None:
+                continue
+            if root_elem is not None and root_elem.text != str(midi):
+                root_elem.text = str(midi)
+                changed = True
+            if low_elem is not None and low_elem.text != str(midi):
+                low_elem.text = str(midi)
+                changed = True
+            if high_elem is not None and high_elem.text != str(midi):
+                high_elem.text = str(midi)
+                changed = True
     return changed


### PR DESCRIPTION
## Summary
- enable note-fixing option in batch editor CLI and GUI
- add helper functions for deriving MIDI notes from filenames or WAV metadata
- document the `--fix-notes` flag in README
- clean up unused import
- handle invalid ProgramPads JSON values during fixes

## Testing
- `python -m py_compile "Gemini wav_TO_XpmV2.py" batch_program_editor.py xpm_parameter_editor.py`
- `python batch_program_editor.py -h`


------
https://chatgpt.com/codex/tasks/task_e_686eec02a05c832b8a9cb47684cadaea