### PR TITLE
Move note helpers to shared module

### DIFF
--- a/xpm_parameter_editor.py
+++ b/xpm_parameter_editor.py
@@ -1,5 +1,8 @@
 import json
 import logging
+import os
+import re
+import struct
 import xml.etree.ElementTree as ET
 from typing import Optional, Dict
 from xml.sax.saxutils import escape as xml_escape, unescape as xml_unescape
@@ -112,3 +115,72 @@ def set_engine_mode(root: ET.Element, mode: str) -> bool:
         changed |= _update_text(legacy_elem, 'False')
 
     return changed
+
+
+def name_to_midi(note_name: str) -> Optional[int]:
+    """Converts a note name (e.g., 'C#4', 'Db-1') to a MIDI note number."""
+    if not note_name:
+        return None
+    note_name_upper = note_name.strip().upper()
+    note_map = {
+        'C': 0,
+        'C#': 1,
+        'DB': 1,
+        'D': 2,
+        'D#': 3,
+        'EB': 3,
+        'E': 4,
+        'F': 5,
+        'F#': 6,
+        'GB': 6,
+        'G': 7,
+        'G#': 8,
+        'AB': 8,
+        'A': 9,
+        'A#': 10,
+        'BB': 10,
+        'B': 11,
+    }
+    m = re.match(r'^([A-G][#B]?)(\-?\d+)$', note_name_upper, re.IGNORECASE)
+    if not m:
+        return None
+    note, octave_str = m.groups()
+    if note not in note_map:
+        return None
+    try:
+        midi = 12 + note_map[note] + 12 * int(octave_str)
+        return midi if 0 <= midi <= 127 else None
+    except (ValueError, TypeError):
+        return None
+
+
+def infer_note_from_filename(filename: str) -> Optional[int]:
+    """Infer a MIDI note from a filename, checking for note names and numbers."""
+    base = os.path.splitext(os.path.basename(filename))[0]
+    m = re.search(r'[ _-]?([A-G][#b]?\-?\d+)', base, re.IGNORECASE)
+    if m:
+        midi = name_to_midi(m.group(1))
+        if midi is not None:
+            return midi
+    m = re.search(r'\b(\d{2,3})\b', base)
+    if m:
+        n = int(m.group(1))
+        if 0 <= n <= 127:
+            return n
+    return None
+
+
+def extract_root_note_from_wav(filepath: str) -> Optional[int]:
+    """Return the MIDI root note from the WAV's smpl chunk if present."""
+    try:
+        with open(filepath, 'rb') as f:
+            data = f.read()
+        idx = data.find(b'smpl')
+        if idx != -1 and idx + 36 <= len(data):
+            root = struct.unpack('<I', data[idx + 28:idx + 32])[0]
+            if 0 <= root <= 127:
+                return root
+    except Exception as e:
+        logging.error("Could not extract root note from WAV %s: %s", filepath, e)
+    return None
+


### PR DESCRIPTION
## Summary
- add `name_to_midi`, `infer_note_from_filename`, and `extract_root_note_from_wav` to `xpm_parameter_editor`
- import these utilities in `Gemini wav_TO_XpmV2.py`
- remove the old local implementations

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_686f11d4271c832bb143a7706736a2a9