### PR TITLE
Fix creative config button responsiveness

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -896,6 +896,7 @@ class BatchProgramEditorWindow(tk.Toplevel):
         self.creative_combo = ttk.Combobox(frame, textvariable=self.creative_var, values=modes, state="readonly")
         self.creative_combo.grid(row=3, column=1, sticky="ew", pady=(10,0))
         self.creative_combo.bind("<<ComboboxSelected>>", self.toggle_config_btn)
+        self.creative_var.trace_add('write', lambda *a: self.toggle_config_btn())
 
         self.config_btn = ttk.Button(frame, text="Configure...", command=self.open_config, state='disabled')
         self.config_btn.grid(row=4, column=1, sticky="e")
@@ -2018,6 +2019,7 @@ class App(tk.Tk):
         self.creative_combo = ttk.Combobox(creative_frame, textvariable=self.creative_mode_var, values=creative_modes, state="readonly")
         self.creative_combo.grid(row=0, column=0, sticky='ew')
         self.creative_combo.bind("<<ComboboxSelected>>", self.on_creative_mode_change)
+        self.creative_mode_var.trace_add('write', lambda *a: self.on_creative_mode_change())
 
         self.creative_config_btn = ttk.Button(creative_frame, text="Configure...", command=self.open_creative_config, state='disabled')
         self.creative_config_btn.grid(row=0, column=1, padx=(5,0))


### PR DESCRIPTION
## Summary
- ensure Creative Mode config button updates whenever the mode variable changes
- likewise update Batch Program Editor's button based on variable change

## Testing
- `python -m py_compile Gemini wav_TO_XpmV2.py`
- `python -m py_compile batch_packager.py batch_program_editor.py drumkit_grouping.py multi_sample_builder.py firmware_profiles.py xpm_parameter_editor.py`
- `xvfb-run -a python - <<'EOF'
import importlib.util
spec = importlib.util.spec_from_file_location('gw', 'Gemini wav_TO_XpmV2.py')
module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(module)
app = module.App()
app.creative_mode_var.set('synth')
app.open_creative_config()
win = [w for w in app.winfo_children() if isinstance(w, module.CreativeModeConfigWindow)][0]
win.save()
app.destroy()
print('ok')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_686f7cb67230832bb138a1052b303868