### PR TITLE
Fix batch program editor UI and argument order

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -990,7 +990,6 @@ class BatchProgramEditorWindow(tk.Toplevel):
         super().__init__(master.root)
         self.master = master
         self.title("Batch Program Editor")
-        self.geometry("400x380")
         self.geometry("400x390")
         self.resizable(False, False)
         self.format_var = tk.StringVar(value="advanced")
@@ -1010,36 +1009,32 @@ class BatchProgramEditorWindow(tk.Toplevel):
                      values=['2.3.0.0','2.6.0.17','3.4.0','3.5.0'], state='readonly').grid(row=1, column=1, sticky="ew", pady=(10,0))
 
         ttk.Label(frame, text="Application Version:").grid(row=2, column=0, sticky="w", pady=(10,0))
-        self.version_var = tk.StringVar()
-        ttk.Entry(frame, textvariable=self.version_var).grid(row=2, column=1, sticky="ew", pady=(10,0))
-        ttk.Label(frame, text="Application Version:").grid(row=1, column=0, sticky="w", pady=(10,0))
         self.version_var = tk.StringVar(value=self.master.firmware_version.get())
         versions = ['2.3.0.0','2.6.0.17','3.4.0','3.5.0']
-        ttk.Combobox(frame, textvariable=self.version_var, values=versions, state="readonly").grid(row=1, column=1, sticky="ew", pady=(10,0))
+        ttk.Combobox(frame, textvariable=self.version_var, values=versions, state="readonly").grid(row=2, column=1, sticky="ew", pady=(10,0))
 
-        ttk.Label(frame, text="Format:").grid(row=2, column=0, sticky="w", pady=(10,0))
+        ttk.Label(frame, text="Format:").grid(row=3, column=0, sticky="w", pady=(10,0))
         self.format_var = tk.StringVar(value="advanced")
-        ttk.Combobox(frame, textvariable=self.format_var, values=["legacy","advanced"], state="readonly").grid(row=2, column=1, sticky="ew", pady=(10,0))
-        ttk.Combobox(frame, textvariable=self.format_var, values=['legacy','advanced'], state="readonly").grid(row=2, column=1, sticky="ew", pady=(10,0))
+        ttk.Combobox(frame, textvariable=self.format_var, values=["legacy","advanced"], state="readonly").grid(row=3, column=1, sticky="ew", pady=(10,0))
 
-        ttk.Label(frame, text="Creative Mode:").grid(row=3, column=0, sticky="w", pady=(10,0))
+        ttk.Label(frame, text="Creative Mode:").grid(row=4, column=0, sticky="w", pady=(10,0))
         self.creative_var = tk.StringVar(value="off")
         modes = ['off', 'subtle', 'synth', 'lofi', 'reverse', 'stereo_spread']
         self.creative_combo = ttk.Combobox(frame, textvariable=self.creative_var, values=modes, state="readonly")
-        self.creative_combo.grid(row=3, column=1, sticky="ew", pady=(10,0))
+        self.creative_combo.grid(row=4, column=1, sticky="ew", pady=(10,0))
         self.creative_combo.bind("<<ComboboxSelected>>", self.toggle_config_btn)
         self.creative_var.trace_add('write', lambda *a: self.toggle_config_btn())
 
         self.config_btn = ttk.Button(frame, text="Configure...", command=self.open_config, state='disabled')
-        self.config_btn.grid(row=4, column=1, sticky="e")
+        self.config_btn.grid(row=5, column=1, sticky="e")
 
-        ttk.Label(frame, text="KeyTrack:").grid(row=5, column=0, sticky="w", pady=(10,0))
+        ttk.Label(frame, text="KeyTrack:").grid(row=6, column=0, sticky="w", pady=(10,0))
         self.keytrack_var = tk.StringVar(value="on")
-        ttk.Combobox(frame, textvariable=self.keytrack_var, values=["on","off"], state="readonly").grid(row=5, column=1, sticky="ew", pady=(10,0))
+        ttk.Combobox(frame, textvariable=self.keytrack_var, values=["on","off"], state="readonly").grid(row=6, column=1, sticky="ew", pady=(10,0))
 
-        ttk.Label(frame, text="Volume ADSR:").grid(row=6, column=0, sticky="w", pady=(10,0))
+        ttk.Label(frame, text="Volume ADSR:").grid(row=7, column=0, sticky="w", pady=(10,0))
         adsr = ttk.Frame(frame)
-        adsr.grid(row=6, column=1, sticky="ew", pady=(10,0))
+        adsr.grid(row=7, column=1, sticky="ew", pady=(10,0))
         self.attack_var = tk.StringVar()
         self.decay_var = tk.StringVar()
         self.sustain_var = tk.StringVar()
@@ -1049,26 +1044,19 @@ class BatchProgramEditorWindow(tk.Toplevel):
         ttk.Entry(adsr, width=4, textvariable=self.sustain_var).pack(side="left")
         ttk.Entry(adsr, width=4, textvariable=self.release_var).pack(side="left", padx=2)
 
-        ttk.Label(frame, text="Mod Matrix File:").grid(row=7, column=0, sticky="w", pady=(10,0))
+        ttk.Label(frame, text="Mod Matrix File:").grid(row=8, column=0, sticky="w", pady=(10,0))
         self.mod_matrix_var = tk.StringVar()
-        entry = ttk.Entry(frame, textvariable=self.mod_matrix_var)
-        entry.grid(row=7, column=1, sticky="ew", pady=(10,0))
-        ttk.Button(frame, text="Browse...", command=self.browse_mod_matrix).grid(row=7, column=2, padx=(5,0), pady=(10,0))
-
-        btn_frame = ttk.Frame(frame)
-        btn_frame.grid(row=8, column=0, columnspan=3, pady=(15,0), sticky="e")
         mm_frame = ttk.Frame(frame)
-        mm_frame.grid(row=7, column=1, sticky="ew", pady=(10,0))
+        mm_frame.grid(row=8, column=1, sticky="ew", pady=(10,0))
         mm_frame.columnconfigure(0, weight=1)
         ttk.Entry(mm_frame, textvariable=self.mod_matrix_var).grid(row=0, column=0, sticky="ew")
         ttk.Button(mm_frame, text="Browse...", command=self.browse_mod_matrix).grid(row=0, column=1, padx=(5,0))
 
         self.fix_notes_var = tk.BooleanVar()
-        ttk.Checkbutton(frame, text="Fix sample notes", variable=self.fix_notes_var).grid(row=8, column=0, columnspan=2, sticky="w", pady=(10,0))
+        ttk.Checkbutton(frame, text="Fix sample notes", variable=self.fix_notes_var).grid(row=9, column=0, columnspan=2, sticky="w", pady=(10,0))
 
         btn_frame = ttk.Frame(frame)
-        btn_frame.grid(row=9, column=0, columnspan=2, pady=(15,0), sticky="e")
-        btn_frame.grid(row=8, column=0, columnspan=2, pady=(15,0), sticky="e")
+        btn_frame.grid(row=10, column=0, columnspan=2, pady=(15,0), sticky="e")
         ttk.Button(btn_frame, text="Apply", command=self.apply_edits).pack(side="right")
         ttk.Button(btn_frame, text="Close", command=self.destroy).pack(side="right", padx=(5,0))
 
@@ -1119,10 +1107,8 @@ class BatchProgramEditorWindow(tk.Toplevel):
             batch_edit_programs,
             self.rename_var.get(),
             self.version_var.get().strip() or None,
-            self.format_var.get(),
             self.firmware_var.get(),
             self.format_var.get(),
-            self.format_var.get().strip() or None,
             self.creative_var.get(),
             self.master.creative_config,
             self.keytrack_var.get() == "on",


### PR DESCRIPTION
## Summary
- tidy Batch Program Editor layout
- ensure run_batch_process passes correct arguments

## Testing
- `python -m py_compile "Gemini wav_TO_XpmV2.py" batch_program_editor.py xpm_parameter_editor.py`

------
https://chatgpt.com/codex/tasks/task_e_686f94e160d4832b97c61bfca5660f6a