### PR TITLE
Update docs with Gemini logging info

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -73,4 +73,10 @@ To maintain stability and organization, new complex features should be developed
   \- \*\*Legacy XPMs (FW 1.x)\*\*: Do not use a JSON block. Sample information is stored directly in \`\<Instrument\>\` \-\> \`\<Layer\>\` \-\> \`\<SampleName\>\` tags. The script must be able to read both.  
 \- \*\*GUI Window Classes\*\*: Each tool (e.g., \`ExpansionDoctorWindow\`, \`BatchProgramEditorWindow\`) is a self-contained \`Toplevel\` window. This modularity should be maintained.
 
-By following these guidelines, we can ensure the continued stability and reliability of the project.  
+By following these guidelines, we can ensure the continued stability and reliability of the project.
+
+## Communication Log
+
+This GitHub repository is linked to the Gemini assistant. Every AI-driven
+change or discussion is archived in [`Codex Communication Log.md`](Codex%20Communication%20Log.md)
+and [`Gemini_Codex_Log.ipynb`](Gemini_Codex_Log.ipynb).

--- a/Codex Communication Log.md
+++ b/Codex Communication Log.md
@@ -1,5 +1,8 @@
-Codex Communication Log"\>  
-\# Gemini \<\> Codex Communication Log
+Codex Communication Log">
+# Gemini <> Codex Communication Log
+
+This log tracks conversations and code updates performed via the Gemini AI assistant. Because this GitHub repository is linked directly to Gemini, any responses or code changes initiated through the assistant automatically appear here and in the accompanying Jupyter notebook (`Gemini_Codex_Log.ipynb`).
+
 
 \---
 

--- a/README.md
+++ b/README.md
@@ -54,3 +54,16 @@ Additional documentation can be found in the [docs/](docs/) directory, including
 ## Development Notes
 
 When modifying or extending the Python scripts, keep function signatures synchronized across all files. If you add or remove parameters in one module, search the repository for that function name and update every call site accordingly. Mismatched argument counts can cause runtime errors that are difficult to debug.
+
+## Gemini <> Codex Communication
+
+This repository is connected to the Gemini AI service. Responses sent through
+Gemini are recorded and stored in two files:
+
+- **`Codex Communication Log.md`** – a human-readable summary of notable
+  exchanges and code changes.
+- **`Gemini_Codex_Log.ipynb`** – a Jupyter notebook capturing detailed
+  interaction history.
+
+Because the GitHub account is linked to Gemini, any future messages or code
+updates made through the assistant will automatically appear in these logs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,12 @@ This folder contains supplementary documentation for using the XPM tools.
 ## Developer Reminder
 
 When updating the code, confirm that any function signature changes are reflected in every file that calls that function. Refer to the [Development Notes](../README.md#development-notes) for more details.
+
+### Communication Logs
+
+All interactions with the Gemini assistant are archived in the repository:
+
+- [`Codex Communication Log.md`](../Codex%20Communication%20Log.md) provides a
+  running summary of notable discussions.
+- [`Gemini_Codex_Log.ipynb`](../Gemini_Codex_Log.ipynb) captures the detailed
+  notebook history.


### PR DESCRIPTION
## Summary
- document the Gemini <> Codex communication link in README
- add communication log references in the docs
- note Gemini integration in AGENT guidelines and the communication log

## Testing
- `python -m py_compile "Gemini wav_TO_XpmV2.py" batch_packager.py batch_program_editor.py drumkit_grouping.py firmware_profiles.py multi_sample_builder.py xpm_parameter_editor.py`

------
https://chatgpt.com/codex/tasks/task_e_686faed73400832bb972546188cdd8c5