### PR TITLE
Fix multi-sample builder format option and engine handling

### DIFF
--- a/firmware_profiles.py
+++ b/firmware_profiles.py
@@ -117,10 +117,20 @@ def get_pad_settings(firmware: str, engine_override: str | None = None):
         settings['universal_pad'] = adv['universal_pad']
         settings['engine'] = 'advanced'
     elif engine_override == 'legacy':
-        leg = PAD_SETTINGS['2.3.0.0']
-        settings['type'] = leg['type']
-        settings['universal_pad'] = leg['universal_pad']
-        settings['engine'] = 'legacy'
+        # Firmware 3.4+ always uses the advanced engine internally. To ensure
+        # the mod matrix and other parameters work correctly we keep the
+        # engine flag set to ``advanced`` even when the user selects a legacy
+        # style program.
+        if firmware in {'3.4.0', '3.5.0'}:
+            adv = PAD_SETTINGS['3.5.0']
+            settings['type'] = adv['type']
+            settings['universal_pad'] = adv['universal_pad']
+            settings['engine'] = 'advanced'
+        else:
+            leg = PAD_SETTINGS['2.3.0.0']
+            settings['type'] = leg['type']
+            settings['universal_pad'] = leg['universal_pad']
+            settings['engine'] = 'legacy'
 
     return settings
 
@@ -132,6 +142,10 @@ def get_program_parameters(
     engine = PAD_SETTINGS.get(firmware, PAD_SETTINGS['3.5.0']).get('engine')
     if engine_override in {'legacy', 'advanced'}:
         engine = engine_override
+        if engine_override == 'legacy' and firmware in {'3.4.0', '3.5.0'}:
+            # Even legacy programs on modern firmware require the advanced
+            # engine flag for full parameter support.
+            engine = 'advanced'
 
     if engine == 'advanced' and ADVANCED_PROGRAM_PARAMS:
         params = ADVANCED_PROGRAM_PARAMS.copy()

--- a/multi_sample_builder.py
+++ b/multi_sample_builder.py
@@ -206,9 +206,30 @@ class MultiSampleBuilderWindow(tk.Toplevel):
 
         popup = tk.Toplevel(self)
         popup.title("Select Build Mode")
+
         mode_var = tk.StringVar(value="multi-sample")
-        ttk.Radiobutton(popup, text="Instrument Keygroup", variable=mode_var, value="multi-sample").pack(anchor="w", padx=10, pady=5)
-        ttk.Radiobutton(popup, text="Drum Program", variable=mode_var, value="drum-kit").pack(anchor="w", padx=10)
+        ttk.Radiobutton(
+            popup,
+            text="Instrument Keygroup",
+            variable=mode_var,
+            value="multi-sample",
+        ).pack(anchor="w", padx=10, pady=5)
+        ttk.Radiobutton(
+            popup, text="Drum Program", variable=mode_var, value="drum-kit"
+        ).pack(anchor="w", padx=10)
+
+        format_frame = ttk.Frame(popup)
+        format_frame.pack(fill="x", padx=10)
+        ttk.Label(format_frame, text="Format:").pack(side="left")
+        format_var = tk.StringVar(value=self.master.format_version.get())
+        ttk.Combobox(
+            format_frame,
+            textvariable=format_var,
+            values=["legacy", "advanced"],
+            state="readonly",
+            width=10,
+        ).pack(side="left", padx=(5, 0))
+
         btn_frame = ttk.Frame(popup)
         btn_frame.pack(fill="x", padx=10, pady=5)
 
@@ -222,8 +243,8 @@ class MultiSampleBuilderWindow(tk.Toplevel):
                 recursive_scan=False,
                 firmware_version=self.master.firmware_version.get(),
                 polyphony=self.master.polyphony_var.get(),
-                format_version=self.master.format_version.get(),
-                creative_config=self.master.creative_config
+                format_version=format_var.get(),
+                creative_config=self.master.creative_config,
             )
             builder = self.builder_cls(self.master.folder_path.get(), self.master, options)
             map_mode = self.map_var.get()


### PR DESCRIPTION
## Summary
- let users choose advanced or legacy format when building multi-samples
- keep `engine` flag set to `advanced` for firmware 3.4+ even when legacy is selected
- adjust program parameter logic accordingly

## Testing
- `python -m py_compile "Gemini wav_TO_XpmV2.py" multi_sample_builder.py firmware_profiles.py`

------
https://chatgpt.com/codex/tasks/task_e_686fbea85d5c832b8933d983b1f2b8cd