### PR TITLE
Fix ProgramPads search logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /__pycache__
 .DS_Store
 *.log
+.venv/

--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -161,7 +161,9 @@ def validate_xpm_file(xpm_path, expected_samples):
         root = ET.fromstring(xml_text)
 
         # Check for modern ProgramPads section
-        pads_elem = root.find('.//ProgramPads-v2.10') or root.find('.//ProgramPads')
+        pads_elem = root.find('.//ProgramPads-v2.10')
+        if pads_elem is None:
+            pads_elem = root.find('.//ProgramPads')
         if pads_elem is not None and pads_elem.text:
             # If it exists, validate its contents
             json_text = xml_unescape(pads_elem.text)


### PR DESCRIPTION
## Summary
- avoid deprecated truthiness check when locating ProgramPads element in `validate_xpm_file`
- ignore local `.venv` folder

## Testing
- `python -m py_compile "Gemini wav_TO_XpmV2.py"`
- `python "Gemini wav_TO_XpmV2.py" > /tmp/script.log 2>&1`

------
https://chatgpt.com/codex/tasks/task_e_68700aab0f34832bbda1d5fa75bff4d2