### PR TITLE
Fix output directory for MultiSampleBuilder

### DIFF
--- a/multi_sample_builder.py
+++ b/multi_sample_builder.py
@@ -313,11 +313,14 @@ class MultiSampleBuilderWindow(tk.Toplevel):
                         break
                     mapping['sample_path'] = os.path.join(self.master.folder_path.get(), f)
                     mappings.append(mapping)
+                output_folder = os.path.dirname(
+                    os.path.join(self.master.folder_path.get(), files[0])
+                )
                 if mappings:
                     builder._create_xpm(
                         name,
                         files,
-                        self.master.folder_path.get(),
+                        output_folder,
                         mode_var.get(),
                         mappings=mappings,
                     )
@@ -328,7 +331,7 @@ class MultiSampleBuilderWindow(tk.Toplevel):
                     builder._create_xpm(
                         name,
                         files,
-                        self.master.folder_path.get(),
+                        output_folder,
                         mode_var.get(),
                         midi_notes=notes,
                     )


### PR DESCRIPTION
## Summary
- ensure multi-sample builder writes created .xpm files into the same directory as the source WAVs

## Testing
- `python -m py_compile multi_sample_builder.py Gemini\ wav_TO_XpmV2.py batch_program_editor.py batch_packager.py drumkit_grouping.py firmware_profiles.py xpm_parameter_editor.py`


------
https://chatgpt.com/codex/tasks/task_e_68701ece8d1c832bb3184db1e731b0c5