### PR TITLE
Fix MergeSubfoldersWindow batch call

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -1243,9 +1243,8 @@ class MergeSubfoldersWindow(tk.Toplevel):
         max_depth = self.max_depth_var.get()
         self.destroy()
         self.master.run_batch_process(
-            merge_subfolders,
-            depth,
-            max_depth,
+            lambda folder, _: merge_subfolders(folder, depth, max_depth),
+            None,
             confirm=True,
             confirm_message="This will move all files up and remove empty folders. This can't be undone. Continue?",
         )


### PR DESCRIPTION
## Summary
- ensure MergeSubfoldersWindow uses run_batch_process correctly

## Testing
- `python -m py_compile 'Gemini wav_TO_XpmV2.py'`


------
https://chatgpt.com/codex/tasks/task_e_68703daffff8832bb24b81f5777590d7