### PR TITLE
Update one-shot builder to honor Keygroup options

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -2379,7 +2379,10 @@ class App(tk.Tk):
 
 
     def build_one_shot_instruments(self):
-        self.build_instruments('one-shot')
+        if IMPORTS_SUCCESSFUL:
+            self.open_window(MultiSampleBuilderWindow, InstrumentBuilder, InstrumentOptions, 'one-shot')
+        else:
+            self.build_instruments('one-shot')
 
     def build_drum_kit_instruments(self):
         self.build_instruments('drum-kit')

--- a/multi_sample_builder.py
+++ b/multi_sample_builder.py
@@ -52,11 +52,12 @@ def parse_filename_mapping(filename):
 class MultiSampleBuilderWindow(tk.Toplevel):
     """Interactive tool for grouping samples and creating multi-sample instruments."""
 
-    def __init__(self, master, builder_cls, options_cls):
+    def __init__(self, master, builder_cls, options_cls, default_mode="multi-sample"):
         super().__init__(master.root)
         self.master = master
         self.builder_cls = builder_cls
         self.options_cls = options_cls
+        self.default_mode = default_mode
         self.title("Multi-Sample Instrument Builder")
         self.geometry("750x500")
         self.groups = {}
@@ -252,7 +253,7 @@ class MultiSampleBuilderWindow(tk.Toplevel):
         popup = tk.Toplevel(self)
         popup.title("Select Build Mode")
 
-        mode_var = tk.StringVar(value="multi-sample")
+        mode_var = tk.StringVar(value=self.default_mode)
         ttk.Radiobutton(
             popup,
             text="Instrument Keygroup",


### PR DESCRIPTION
## Summary
- allow `MultiSampleBuilderWindow` to accept a default build mode
- call `MultiSampleBuilderWindow` for one-shot builds so Keygroup options apply

## Testing
- `python -m py_compile "Gemini wav_TO_XpmV2.py" "multi_sample_builder.py"`

------
https://chatgpt.com/codex/tasks/task_e_68705a209dc8832b93af042e7fdd573d