### PR TITLE
Enhance batch fixer to rebuild with unmapped samples

### DIFF
--- a/Batch Program Fixer - Changelog.md
+++ b/Batch Program Fixer - Changelog.md
@@ -47,6 +47,7 @@ The logic was re-engineered to handle batch operations efficiently.
 * **Looping Rebuild:** When you click "Rebuild Selected," the tool iterates through every program you've checked.  
 * **Robust Parsing & Rebuilding:** For each program, it performs the same "Clean Slate Rebuild" as before—parsing the sample map and using the InstrumentBuilder to generate a brand new, clean .xpm file targeted to your selected firmware.  
 * **Status Updates:** The status for each file is updated in the list in real-time, showing "Rebuilding...", "Rebuilt", or "Error".
+* **Unmapped Sample Detection:** The fixer now scans each program's folder for audio files not referenced in the XPM. Any missing mappings are automatically included when the program is rebuilt.
 
 ## **3\. Critical Bug Fix**
 


### PR DESCRIPTION
## Summary
- import `AUDIO_EXTS` and add helper to detect audio files not used in an XPM
- extend `rebuild_batch` so missing audio files are automatically added during rebuild
- document unmapped sample detection in the batch program fixer changelog

## Testing
- `python -m py_compile 'Gemini wav_TO_XpmV2.py'`

------
https://chatgpt.com/codex/tasks/task_e_6870619b27fc832b9e3a9c3893acb9e9