### PR TITLE
Fix XPM export formatting

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -87,6 +87,12 @@ def indent_tree(tree, space="  "):
                     elem.tail = i
             elif level and (not elem.tail or not elem.tail.strip()):
                 elem.tail = i
+        _indent(tree.getroot())
+
+    # Ensure newline at end of file for consistency
+    root = tree.getroot()
+    if not (root.tail and root.tail.endswith("\n")):
+        root.tail = "\n"
 
         _indent(tree.getroot())
 

--- a/batch_program_editor.py
+++ b/batch_program_editor.py
@@ -25,6 +25,10 @@ def indent_tree(tree: ET.ElementTree, space: str = "  ") -> None:
 
         _indent(tree.getroot())
 
+    root = tree.getroot()
+    if not (root.tail and root.tail.endswith("\n")):
+        root.tail = "\n"
+
 from xpm_parameter_editor import (
     set_layer_keytrack,
     set_volume_adsr,


### PR DESCRIPTION
## Summary
- normalize indent_tree to ensure a trailing newline on exported XML
- apply the same newline logic in batch_program_editor

## Testing
- `python -m py_compile "Gemini wav_TO_XpmV2.py" batch_program_editor.py`

------
https://chatgpt.com/codex/tasks/task_e_68707c36fe4c832b9e5b22d4ae06cebb