### PR TITLE
Update docs about keygroup mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Additional documentation can be found in the [docs/](docs/) directory, including
   The matrix file should be a `.json` list where each entry contains a `Num` value and the desired
   parameters for that modulation slot.
   parameters for that modulation slot. The command-line version exposes the same options via
-  `--format`, `--mod-matrix`, and the new `--fix-notes` flag for repairing sample note assignments.
+  `--format`, `--mod-matrix`, and the new `--fix-notes` flag for repairing sample note assignments. The `--verify-map` option can also rebuild programs when extra WAV files are found, assigning them to new keygroups based on their filenames.
 - `batch_program_editor.py` – batch editor for `.xpm` program files allowing rename, firmware, and format changes.
   This functionality is also accessible from the GUI via **Batch Program Editor...** under Advanced Tools.
   The editor now provides drop-down selectors for **Application Version** and **Format**

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,8 @@
 
 This folder contains supplementary documentation for using the XPM tools.
 
-- [Drum vs Instrument Keygroups](drum_vs_instrument_keygroups.md) – explains key differences and provides guidelines for generating drum kits.
+- [Drum vs Instrument Keygroups](drum_vs_instrument_keygroups.md) – explains key differences and provides guidelines for generating drum kits and instruments.
+- The `--verify-map` feature of `batch_program_editor.py` automatically assigns any unreferenced samples to new keygroups using note names extracted from file names.
 
 ## Developer Reminder
 


### PR DESCRIPTION
## Summary
- clarify per-sample keygroup mapping and velocity layer usage in docs
- document the `--verify-map` feature

## Testing
- `python -m py_compile Gemini\ wav_TO_XpmV2.py batch_program_editor.py batch_packager.py drumkit_grouping.py firmware_profiles.py multi_sample_builder.py xpm_parameter_editor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870ffbc4628832b891c94906221a7e1