### PR TITLE
Add automatic pitch detection for WAV files

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -2130,7 +2130,7 @@ class InstrumentBuilder:
                 'is_valid': True,
                 'path': sample_path,
                 'frames': frames,
-                'root_note': extract_root_note_from_wav(sample_path),
+                'root_note': extract_root_note_from_wav(sample_path) or infer_note_from_filename(sample_path),
                 'is_scw': is_scw
             }
         except Exception as e:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Additional documentation can be found in the [docs/](docs/) directory, including
 - Multi-sample builder prompts for Drum Program or Instrument Keygroup when building.
 - Expansion Builder resizes uploaded artwork to 600x600 if Pillow is installed.
 - Expansion Doctor can rewrite programs to any firmware version and legacy or advanced format.
+- Unknown samples without note metadata are now analyzed to detect their pitch automatically.
 
 ## Installation
 
@@ -45,6 +46,7 @@ Additional documentation can be found in the [docs/](docs/) directory, including
    ```bash
    pip install -r requirements.txt
    ```
+   The package list includes **soundfile** and **numpy** which are required for automatic pitch detection.
 2. Launch the GUI:
    ```bash
     python "Gemini wav_TO_XpmV2.py"

--- a/audio_pitch.py
+++ b/audio_pitch.py
@@ -1,0 +1,39 @@
+"""Utility functions for audio analysis."""
+
+from __future__ import annotations
+
+import logging
+from math import log2
+from typing import Optional
+
+import numpy as np
+import soundfile as sf
+
+
+def detect_fundamental_pitch(path: str) -> Optional[int]:
+    """Return the estimated MIDI pitch of ``path`` using a simple FFT analysis."""
+
+    try:
+        data, sr = sf.read(path, always_2d=True)
+        if data.size == 0 or sr <= 0:
+            return None
+        mono = data.mean(axis=1)
+        n = min(len(mono), int(sr))  # analyze up to the first second
+        if n <= 16:
+            return None
+        segment = mono[:n]
+        segment = segment - float(np.mean(segment))
+        window = np.hanning(len(segment))
+        spectrum = np.fft.rfft(segment * window)
+        mags = np.abs(spectrum)
+        if len(mags) < 2:
+            return None
+        peak_index = int(np.argmax(mags[1:]) + 1)
+        freq = peak_index * sr / len(segment)
+        if freq <= 0:
+            return None
+        midi = round(69 + 12 * log2(freq / 440.0))
+        return midi if 0 <= midi <= 127 else None
+    except Exception as exc:
+        logging.error("Pitch detection failed for %s: %s", path, exc)
+        return None

--- a/docs/drum_vs_instrument_keygroups.md
+++ b/docs/drum_vs_instrument_keygroups.md
@@ -147,6 +147,7 @@ Each sample occupies its own keygroup. The `Number` tag should match the keygrou
 ## 6. Automatic Mapping Repairs
 
 The `batch_program_editor.py` tool offers a `--verify-map` mode. When enabled it searches each program's folder for audio files that are not referenced in the XPM. Any extras are assigned to new keygroups automatically. The target note is guessed from the file name (e.g., `Piano_C3.wav` → MIDI 60) or extracted from WAV metadata if present.
+If no metadata is found, the tools now analyze the sample itself to detect its fundamental pitch automatically.
 
 ---
 

--- a/xpm_parameter_editor.py
+++ b/xpm_parameter_editor.py
@@ -11,6 +11,8 @@ import xml.etree.ElementTree as ET
 from typing import Dict, Optional
 from xml.sax.saxutils import escape as xml_escape, unescape as xml_unescape
 
+from audio_pitch import detect_fundamental_pitch
+
 
 def _update_text(elem: Optional[ET.Element], value: Optional[str]) -> bool:
     """Update ``elem.text`` if ``value`` differs.
@@ -193,7 +195,11 @@ def infer_note_from_filename(filename: str) -> Optional[int]:
 
 
 def extract_root_note_from_wav(filepath: str) -> Optional[int]:
-    """Return the MIDI root note from the WAV ``smpl`` chunk if present."""
+    """Return the MIDI root note from a WAV file.
+
+    If the ``smpl`` chunk is missing, a short segment of the audio is
+    analyzed to estimate the pitch.
+    """
 
     try:
         with open(filepath, 'rb') as f:
@@ -205,7 +211,8 @@ def extract_root_note_from_wav(filepath: str) -> Optional[int]:
                 return note
     except Exception as exc:
         logging.error("Could not extract root note from WAV %s: %s", filepath, exc)
-    return None
+
+    return detect_fundamental_pitch(filepath)
 
 
 def fix_sample_notes(root: ET.Element, folder: str) -> bool:


### PR DESCRIPTION
## Summary
- implement `audio_pitch.detect_fundamental_pitch` using soundfile and numpy
- use the new helper when extracting root notes from WAV files
- fall back to filename guessing when validating samples
- document automatic pitch detection and dependency notes

## Testing
- `python -m py_compile 'Gemini wav_TO_XpmV2.py' batch_program_editor.py batch_packager.py drumkit_grouping.py firmware_profiles.py multi_sample_builder.py xpm_parameter_editor.py audio_pitch.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687104643044832b8f3fa0cce3bafef4