### PR TITLE
Fix ElementTree truthiness deprecations

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -166,7 +166,9 @@ def validate_xpm_file(xpm_path, expected_samples):
         root = ET.fromstring(xml_text)
 
         # Check for modern ProgramPads section
-        pads_elem = root.find('.//ProgramPads-v2.10') or root.find('.//ProgramPads')
+        pads_elem = root.find('.//ProgramPads-v2.10')
+        if pads_elem is None:
+            pads_elem = root.find('.//ProgramPads')
         if pads_elem is not None and pads_elem.text:
             # If it exists, validate its contents
             json_text = xml_unescape(pads_elem.text)
@@ -260,7 +262,9 @@ def parse_xpm_samples(xpm_path):
         tree = ET.parse(xpm_path)
         root = tree.getroot()
 
-        pads_elem = root.find('.//ProgramPads-v2.10') or root.find('.//ProgramPads')
+        pads_elem = root.find('.//ProgramPads-v2.10')
+        if pads_elem is None:
+            pads_elem = root.find('.//ProgramPads')
         if pads_elem is not None and pads_elem.text:
             try:
                 data = json.loads(xml_unescape(pads_elem.text))
@@ -492,7 +496,9 @@ class ExpansionDoctorWindow(tk.Toplevel):
                 keygroup_mode.text = val
                 changed = True
 
-        pads_elem = program.find('ProgramPads-v2.10') or program.find('ProgramPads')
+        pads_elem = program.find('ProgramPads-v2.10')
+        if pads_elem is None:
+            pads_elem = program.find('ProgramPads')
         if pads_elem is not None and pads_elem.text:
             try:
                 data = json.loads(xml_unescape(pads_elem.text))
@@ -1592,7 +1598,9 @@ class BatchProgramFixerWindow(tk.Toplevel):
                     inst_params[child.tag] = child.text or ''
 
         # Modern JSON-based format (v3.4+)
-        pads_elem = root.find('.//ProgramPads-v2.10') or root.find('.//ProgramPads')
+        pads_elem = root.find('.//ProgramPads-v2.10')
+        if pads_elem is None:
+            pads_elem = root.find('.//ProgramPads')
         if pads_elem is not None and pads_elem.text:
             try:
                 data = json.loads(xml_unescape(pads_elem.text))
@@ -2053,7 +2061,9 @@ class InstrumentBuilder:
                 preview_sample_name = None
 
                 # Modern format check (JSON inside ProgramPads)
-                pads_elem = root.find('.//ProgramPads-v2.10') or root.find('.//ProgramPads')
+                pads_elem = root.find('.//ProgramPads-v2.10')
+                if pads_elem is None:
+                    pads_elem = root.find('.//ProgramPads')
                 if pads_elem is not None and pads_elem.text:
                     pads_data = json.loads(xml_unescape(pads_elem.text))
                     pads = pads_data.get('pads', {})
@@ -2789,7 +2799,9 @@ def _parse_xpm_for_rebuild(xpm_path):
                 instrument_params[child.tag] = child.text
 
     # Try parsing modern JSON format first
-    pads_elem = root.find('.//ProgramPads-v2.10') or root.find('.//ProgramPads')
+    pads_elem = root.find('.//ProgramPads-v2.10')
+    if pads_elem is None:
+        pads_elem = root.find('.//ProgramPads')
     if pads_elem is not None and pads_elem.text:
         try:
             data = json.loads(xml_unescape(pads_elem.text))


### PR DESCRIPTION
## Summary
- avoid boolean evaluation of XML Elements
- silence Python's upcoming ElementTree truthiness deprecation warnings

## Testing
- `python -m py_compile 'Gemini wav_TO_XpmV2.py'`

------
https://chatgpt.com/codex/tasks/task_e_68710bdac5b4832b8021649cd12de445