### PR TITLE
Enhance multi-sample builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Additional documentation can be found in the [docs/](docs/) directory, including
 - Expansion Doctor displays invalid or corrupt `.xpm` files instead of skipping them.
 - Auto Group Folders now previews folder names with sample counts before grouping.
 - Multi-sample builder prompts for Drum Program or Instrument Keygroup when building.
+- Multi-sample builder can group selected files by prefix and rename groups.
+- Root notes can be detected from WAVs and appended to filenames automatically.
 - Expansion Builder resizes uploaded artwork to 600x600 if Pillow is installed.
 - Expansion Doctor can rewrite programs to any firmware version and legacy or advanced format.
 - Unknown samples without note metadata are now analyzed to detect their pitch automatically.


### PR DESCRIPTION
## Summary
- add group renaming and group-by-prefix features to multi sample builder
- fix file selection bug when adding samples to groups
- allow root note detection to rename samples automatically
- document new capabilities in README

## Testing
- `python -m py_compile multi_sample_builder.py`
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_68710ea4fbb4832bb0d26c80fe5e308f