### PR TITLE
Update multisample auto grouping

### DIFF
--- a/multi_sample_builder.py
+++ b/multi_sample_builder.py
@@ -240,11 +240,13 @@ class MultiSampleBuilderWindow(tk.Toplevel):
         self.refresh_group_files()
 
     def auto_group_folders(self):
-        """Preview and group unassigned samples by their parent folders."""
+        """Preview and group unassigned samples by common filename prefixes."""
         counts = {}
         for f in self.unassigned:
-            folder = os.path.dirname(f)
-            name = os.path.basename(folder) if folder else os.path.basename(self.master.folder_path.get())
+            name, _ = parse_filename_mapping(f)
+            if not name:
+                base = os.path.splitext(os.path.basename(f))[0]
+                name = re.split(r"[ _-]+", base)[0]
             counts[name] = counts.get(name, 0) + 1
 
         preview = tk.Toplevel(self)
@@ -252,7 +254,7 @@ class MultiSampleBuilderWindow(tk.Toplevel):
         preview.geometry("300x300")
 
         tree = ttk.Treeview(preview, columns=("count"), show="headings")
-        tree.heading("#1", text="Folder")
+        tree.heading("#1", text="Group")
         tree.heading("count", text="Files")
         for folder, cnt in sorted(counts.items()):
             tree.insert("", "end", values=(folder, cnt))
@@ -263,8 +265,10 @@ class MultiSampleBuilderWindow(tk.Toplevel):
 
         def do_group():
             for f in list(self.unassigned):
-                folder = os.path.dirname(f)
-                name = os.path.basename(folder) if folder else os.path.basename(self.master.folder_path.get())
+                name, _ = parse_filename_mapping(f)
+                if not name:
+                    base = os.path.splitext(os.path.basename(f))[0]
+                    name = re.split(r"[ _-]+", base)[0]
                 self.groups.setdefault(name, []).append(f)
                 self.unassigned.remove(f)
             self.refresh_file_list()


### PR DESCRIPTION
## Summary
- group files by common filename prefix when using **Auto Group Folders**
- show counts for each prefix in the preview dialog

## Testing
- `python -m py_compile multi_sample_builder.py`
- `python -m py_compile 'Gemini wav_TO_XpmV2.py'`


------
https://chatgpt.com/codex/tasks/task_e_687112484e78832ba07580cee960bb8b