### PR TITLE
Fix Batch Program Fixer sample mixing

### DIFF
--- a/Batch Program Fixer - Changelog.md
+++ b/Batch Program Fixer - Changelog.md
@@ -47,7 +47,10 @@ The logic was re-engineered to handle batch operations efficiently.
 * **Looping Rebuild:** When you click "Rebuild Selected," the tool iterates through every program you've checked.  
 * **Robust Parsing & Rebuilding:** For each program, it performs the same "Clean Slate Rebuild" as before—parsing the sample map and using the InstrumentBuilder to generate a brand new, clean .xpm file targeted to your selected firmware.  
 * **Status Updates:** The status for each file is updated in the list in real-time, showing "Rebuilding...", "Rebuilt", or "Error".
-* **Unmapped Sample Detection:** The fixer now scans each program's folder for audio files not referenced in the XPM. Any missing mappings are automatically included when the program is rebuilt.
+* **Unmapped Sample Detection:** The fixer scans each program's folder for audio
+  files not referenced in the XPM. Starting with this release, you are asked
+  whether to include these extras when rebuilding instead of adding them
+  automatically.
 
 ## **3\. Critical Bug Fix**
 

--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -1582,18 +1582,28 @@ class BatchProgramFixerWindow(tk.Toplevel):
                     continue
 
                 extra_files = find_unreferenced_audio_files(xpm_path, sample_mappings)
-                for path in extra_files:
-                    midi = extract_root_note_from_wav(path) or infer_note_from_filename(path)
-                    if midi is None:
-                        midi = 60
-                    sample_mappings.append({
-                        'sample_path': path,
-                        'root_note': midi,
-                        'low_note': midi,
-                        'high_note': midi,
-                        'velocity_low': 0,
-                        'velocity_high': 127,
-                    })
+                if extra_files and self._ask_yesno_safe(
+                    "Include Unreferenced Samples?",
+                    (
+                        f"Found {len(extra_files)} additional audio file(s) in the folder for "
+                        f"{os.path.basename(xpm_path)} that are not referenced.\n"
+                        "Include these samples when rebuilding?"
+                    ),
+                ):
+                    for path in extra_files:
+                        midi = extract_root_note_from_wav(path) or infer_note_from_filename(path)
+                        if midi is None:
+                            midi = 60
+                        sample_mappings.append(
+                            {
+                                'sample_path': path,
+                                'root_note': midi,
+                                'low_note': midi,
+                                'high_note': midi,
+                                'velocity_low': 0,
+                                'velocity_high': 127,
+                            }
+                        )
 
                 program_name = os.path.splitext(os.path.basename(xpm_path))[0]
                 output_folder = os.path.dirname(xpm_path)

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,10 @@
 This folder contains supplementary documentation for using the XPM tools.
 
 - [Drum vs Instrument Keygroups](drum_vs_instrument_keygroups.md) – explains key differences and provides guidelines for generating drum kits and instruments.
-- The `--verify-map` feature of `batch_program_editor.py` automatically assigns any unreferenced samples to new keygroups using note names extracted from file names.
+- The `--verify-map` feature of `batch_program_editor.py` can assign unreferenced
+  samples to new keygroups using note names from filenames. When rebuilding
+  programs through the GUI, you will now be prompted before these extras are
+  included.
 
 ## Developer Reminder
 


### PR DESCRIPTION
## Summary
- prompt before including unreferenced audio files when rebuilding
- document new prompt behaviour in docs and changelog

## Testing
- `python -m py_compile 'Gemini wav_TO_XpmV2.py' batch_program_editor.py`

------
https://chatgpt.com/codex/tasks/task_e_68711fc4024c832ba6db0e4cadcd286f