### PR TITLE
Handle newer ProgramPads tags

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -36,6 +36,7 @@ try:
         set_engine_mode,
         set_application_version,
         fix_sample_notes,
+        find_program_pads,
         name_to_midi,
         infer_note_from_filename,
         extract_root_note_from_wav,
@@ -166,9 +167,7 @@ def validate_xpm_file(xpm_path, expected_samples):
         root = ET.fromstring(xml_text)
 
         # Check for modern ProgramPads section
-        pads_elem = root.find('.//ProgramPads-v2.10')
-        if pads_elem is None:
-            pads_elem = root.find('.//ProgramPads')
+        pads_elem = find_program_pads(root)
         if pads_elem is not None and pads_elem.text:
             # If it exists, validate its contents
             json_text = xml_unescape(pads_elem.text)
@@ -262,9 +261,7 @@ def parse_xpm_samples(xpm_path):
         tree = ET.parse(xpm_path)
         root = tree.getroot()
 
-        pads_elem = root.find('.//ProgramPads-v2.10')
-        if pads_elem is None:
-            pads_elem = root.find('.//ProgramPads')
+        pads_elem = find_program_pads(root)
         if pads_elem is not None and pads_elem.text:
             try:
                 data = json.loads(xml_unescape(pads_elem.text))
@@ -544,9 +541,7 @@ class ExpansionDoctorWindow(tk.Toplevel):
                 keygroup_mode.text = val
                 changed = True
 
-        pads_elem = program.find('ProgramPads-v2.10')
-        if pads_elem is None:
-            pads_elem = program.find('ProgramPads')
+        pads_elem = find_program_pads(program)
         if pads_elem is not None and pads_elem.text:
             try:
                 data = json.loads(xml_unescape(pads_elem.text))
@@ -1656,9 +1651,7 @@ class BatchProgramFixerWindow(tk.Toplevel):
                     inst_params[child.tag] = child.text or ''
 
         # Modern JSON-based format (v3.4+)
-        pads_elem = root.find('.//ProgramPads-v2.10')
-        if pads_elem is None:
-            pads_elem = root.find('.//ProgramPads')
+        pads_elem = find_program_pads(root)
         if pads_elem is not None and pads_elem.text:
             try:
                 data = json.loads(xml_unescape(pads_elem.text))
@@ -2121,9 +2114,7 @@ class InstrumentBuilder:
                 preview_sample_name = None
 
                 # Modern format check (JSON inside ProgramPads)
-                pads_elem = root.find('.//ProgramPads-v2.10')
-                if pads_elem is None:
-                    pads_elem = root.find('.//ProgramPads')
+                pads_elem = find_program_pads(root)
                 if pads_elem is not None and pads_elem.text:
                     pads_data = json.loads(xml_unescape(pads_elem.text))
                     pads = pads_data.get('pads', {})
@@ -2859,9 +2850,7 @@ def _parse_xpm_for_rebuild(xpm_path):
                 instrument_params[child.tag] = child.text
 
     # Try parsing modern JSON format first
-    pads_elem = root.find('.//ProgramPads-v2.10')
-    if pads_elem is None:
-        pads_elem = root.find('.//ProgramPads')
+    pads_elem = find_program_pads(root)
     if pads_elem is not None and pads_elem.text:
         try:
             data = json.loads(xml_unescape(pads_elem.text))

--- a/batch_program_editor.py
+++ b/batch_program_editor.py
@@ -37,6 +37,7 @@ from xpm_parameter_editor import (
     set_engine_mode,
     set_application_version,
     fix_sample_notes,
+    find_program_pads,
     infer_note_from_filename,
     extract_root_note_from_wav,
 )
@@ -99,7 +100,7 @@ def parse_any_xpm(xpm_path: str):
             if len(list(child)) == 0:
                 inst_params[child.tag] = child.text or ''
 
-    pads_elem = root.find('.//ProgramPads-v2.10') or root.find('.//ProgramPads')
+    pads_elem = find_program_pads(root)
     if pads_elem is not None and pads_elem.text:
         try:
             data = json.loads(xml_unescape(pads_elem.text))

--- a/firmware_profiles.py
+++ b/firmware_profiles.py
@@ -55,7 +55,7 @@ def _load_advanced_params():
         return advanced
 
     for child in program:
-        if child.tag in {'ProgramName', 'ProgramPads-v2.10', 'Instruments', 'Version'}:
+        if child.tag in {'ProgramName', 'Instruments', 'Version'} or child.tag.startswith('ProgramPads'):
             continue
         if len(list(child)) == 0:
             advanced[child.tag] = child.text or ''

--- a/xpm_parameter_editor.py
+++ b/xpm_parameter_editor.py
@@ -27,6 +27,21 @@ def _update_text(elem: Optional[ET.Element], value: Optional[str]) -> bool:
     return False
 
 
+def find_program_pads(root: ET.Element) -> Optional[ET.Element]:
+    """Return the ProgramPads element regardless of version."""
+
+    pads_elem = root.find('.//ProgramPads-v2.10')
+    if pads_elem is None:
+        pads_elem = root.find('.//ProgramPads')
+    if pads_elem is not None:
+        return pads_elem
+
+    for elem in root.iter():
+        tag = getattr(elem, 'tag', '')
+        if isinstance(tag, str) and tag.startswith('ProgramPads-v'):
+            return elem
+    return None
+
 def set_layer_keytrack(root: ET.Element, keytrack: bool) -> bool:
     """Enable or disable KeyTrack on all ``Layer`` elements."""
 
@@ -116,7 +131,7 @@ def set_engine_mode(root: ET.Element, mode: str) -> bool:
 
     changed = False
 
-    pads_elem = root.find('.//ProgramPads-v2.10') or root.find('.//ProgramPads')
+    pads_elem = find_program_pads(root)
     if pads_elem is not None and pads_elem.text:
         try:
             data = json.loads(xml_unescape(pads_elem.text))
@@ -222,7 +237,7 @@ def fix_sample_notes(root: ET.Element, folder: str) -> bool:
 
     changed = False
 
-    pads_elem = root.find('.//ProgramPads-v2.10') or root.find('.//ProgramPads')
+    pads_elem = find_program_pads(root)
     if pads_elem is not None and pads_elem.text:
         try:
             data = json.loads(xml_unescape(pads_elem.text))


### PR DESCRIPTION
## Summary
- support additional `ProgramPads-v*` tags by adding `find_program_pads`
- update parsing logic in main script and batch editor
- ignore any ProgramPads variant while loading firmware profiles

## Testing
- `python -m py_compile "Gemini wav_TO_XpmV2.py" batch_program_editor.py xpm_parameter_editor.py firmware_profiles.py`

------
https://chatgpt.com/codex/tasks/task_e_6871219d9428832bb4460968748db27d