### PR TITLE
Add XPM note correction tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Additional documentation can be found in the [docs/](docs/) directory, including
   parameters for that modulation slot.
   parameters for that modulation slot. The command-line version exposes the same options via
   `--format`, `--mod-matrix`, and the new `--fix-notes` flag for repairing sample note assignments. The `--verify-map` option can also rebuild programs when extra WAV files are found, assigning them to new keygroups based on their filenames.
+- `fix_xpm_notes.py` – standalone utility to repair root note mappings in existing programs. Point it at a single file or a folder of programs to rewrite each `.xpm` with corrected notes.
 - `batch_program_editor.py` – batch editor for `.xpm` program files allowing rename, firmware, and format changes.
   This functionality is also accessible from the GUI via **Batch Program Editor...** under Advanced Tools.
   The editor now provides drop-down selectors for **Application Version** and **Format**
@@ -41,6 +42,7 @@ Additional documentation can be found in the [docs/](docs/) directory, including
 - Expansion Builder resizes uploaded artwork to 600x600 if Pillow is installed.
 - Expansion Doctor can rewrite programs to any firmware version and legacy or advanced format.
 - Unknown samples without note metadata are now analyzed to detect their pitch automatically.
+- `fix_xpm_notes.py` uses the same detection logic to correct older programs that were mapped incorrectly.
 
 ## Installation
 

--- a/fix_xpm_notes.py
+++ b/fix_xpm_notes.py
@@ -1,0 +1,41 @@
+import os
+import argparse
+import xml.etree.ElementTree as ET
+
+from xpm_parameter_editor import fix_sample_notes, indent_tree
+
+
+def fix_file(path: str) -> bool:
+    """Apply note fixes to one XPM file."""
+    try:
+        tree = ET.parse(path)
+        root = tree.getroot()
+    except ET.ParseError as exc:
+        print(f"Parse error in {path}: {exc}")
+        return False
+
+    if fix_sample_notes(root, os.path.dirname(path)):
+        indent_tree(tree)
+        tree.write(path, encoding="utf-8", xml_declaration=True)
+        print(f"Fixed {path}")
+        return True
+    return False
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Fix root notes in XPM programs")
+    parser.add_argument("path", help="XPM file or folder")
+    args = parser.parse_args()
+
+    target = args.path
+    if os.path.isfile(target):
+        fix_file(target)
+    else:
+        for root_dir, _, files in os.walk(target):
+            for name in files:
+                if name.lower().endswith(".xpm"):
+                    fix_file(os.path.join(root_dir, name))
+
+
+if __name__ == "__main__":
+    main()

--- a/xpm_parameter_editor.py
+++ b/xpm_parameter_editor.py
@@ -11,6 +11,7 @@ import xml.etree.ElementTree as ET
 from typing import Dict, Optional
 from xml.sax.saxutils import escape as xml_escape, unescape as xml_unescape
 
+from audio_pitch import detect_fundamental_pitch
 
 
 def _update_text(elem: Optional[ET.Element], value: Optional[str]) -> bool:
@@ -30,25 +31,26 @@ def _update_text(elem: Optional[ET.Element], value: Optional[str]) -> bool:
 def find_program_pads(root: ET.Element) -> Optional[ET.Element]:
     """Return the ProgramPads element regardless of version."""
 
-    pads_elem = root.find('.//ProgramPads-v2.10')
+    pads_elem = root.find(".//ProgramPads-v2.10")
     if pads_elem is None:
-        pads_elem = root.find('.//ProgramPads')
+        pads_elem = root.find(".//ProgramPads")
     if pads_elem is not None:
         return pads_elem
 
     for elem in root.iter():
-        tag = getattr(elem, 'tag', '')
-        if isinstance(tag, str) and tag.startswith('ProgramPads-v'):
+        tag = getattr(elem, "tag", "")
+        if isinstance(tag, str) and tag.startswith("ProgramPads-v"):
             return elem
     return None
+
 
 def set_layer_keytrack(root: ET.Element, keytrack: bool) -> bool:
     """Enable or disable KeyTrack on all ``Layer`` elements."""
 
     changed = False
     val = "True" if keytrack else "False"
-    for layer in root.findall('.//Layer'):
-        changed |= _update_text(layer.find('KeyTrack'), val)
+    for layer in root.findall(".//Layer"):
+        changed |= _update_text(layer.find("KeyTrack"), val)
     return changed
 
 
@@ -62,11 +64,19 @@ def set_volume_adsr(
     """Update the volume envelope ADSR values."""
 
     changed = False
-    for inst in root.findall('.//Instrument'):
-        changed |= _update_text(inst.find('VolumeAttack'), str(attack) if attack is not None else None)
-        changed |= _update_text(inst.find('VolumeDecay'), str(decay) if decay is not None else None)
-        changed |= _update_text(inst.find('VolumeSustain'), str(sustain) if sustain is not None else None)
-        changed |= _update_text(inst.find('VolumeRelease'), str(release) if release is not None else None)
+    for inst in root.findall(".//Instrument"):
+        changed |= _update_text(
+            inst.find("VolumeAttack"), str(attack) if attack is not None else None
+        )
+        changed |= _update_text(
+            inst.find("VolumeDecay"), str(decay) if decay is not None else None
+        )
+        changed |= _update_text(
+            inst.find("VolumeSustain"), str(sustain) if sustain is not None else None
+        )
+        changed |= _update_text(
+            inst.find("VolumeRelease"), str(release) if release is not None else None
+        )
     return changed
 
 
@@ -77,7 +87,7 @@ def load_mod_matrix(path: str) -> Dict[int, Dict[str, str]]:
     """
 
     try:
-        with open(path, 'r', encoding='utf-8') as f:
+        with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
     except (OSError, json.JSONDecodeError) as exc:
         logging.error("Could not load mod matrix '%s': %s", path, exc)
@@ -86,10 +96,10 @@ def load_mod_matrix(path: str) -> Dict[int, Dict[str, str]]:
     matrix: Dict[int, Dict[str, str]] = {}
     if isinstance(data, list):
         for entry in data:
-            num = entry.get('Num')
+            num = entry.get("Num")
             if num is None:
                 continue
-            matrix[int(num)] = {k: str(v) for k, v in entry.items() if k != 'Num'}
+            matrix[int(num)] = {k: str(v) for k, v in entry.items() if k != "Num"}
     elif isinstance(data, dict):
         for num, params in data.items():
             matrix[int(num)] = {k: str(v) for k, v in params.items()}
@@ -101,9 +111,9 @@ def apply_mod_matrix(root: ET.Element, matrix: Dict[int, Dict[str, str]]) -> boo
     """Apply modulation matrix values to existing ``ModLink`` elements."""
 
     changed = False
-    for link in root.findall('.//ModLink'):
+    for link in root.findall(".//ModLink"):
         try:
-            num = int(link.get('Num', -1))
+            num = int(link.get("Num", -1))
         except ValueError:
             continue
         params = matrix.get(num)
@@ -119,14 +129,14 @@ def apply_mod_matrix(root: ET.Element, matrix: Dict[int, Dict[str, str]]) -> boo
 def set_application_version(root: ET.Element, version: Optional[str]) -> bool:
     """Set the ``Application_Version`` element to ``version``."""
 
-    ver_elem = root.find('.//Application_Version')
+    ver_elem = root.find(".//Application_Version")
     return _update_text(ver_elem, version)
 
 
 def set_engine_mode(root: ET.Element, mode: str) -> bool:
     """Switch between legacy and advanced engine modes."""
 
-    if mode not in {'legacy', 'advanced'}:
+    if mode not in {"legacy", "advanced"}:
         return False
 
     changed = False
@@ -139,13 +149,13 @@ def set_engine_mode(root: ET.Element, mode: str) -> bool:
             data = {}
         if not isinstance(data, dict):
             data = {}
-        if data.get('engine') != mode:
-            data['engine'] = mode
+        if data.get("engine") != mode:
+            data["engine"] = mode
             pads_elem.text = xml_escape(json.dumps(data, indent=4))
             changed = True
 
-    legacy_elem = root.find('.//KeygroupLegacyMode')
-    changed |= _update_text(legacy_elem, 'True' if mode == 'legacy' else 'False')
+    legacy_elem = root.find(".//KeygroupLegacyMode")
+    changed |= _update_text(legacy_elem, "True" if mode == "legacy" else "False")
     return changed
 
 
@@ -157,26 +167,26 @@ def name_to_midi(note_name: str) -> Optional[int]:
 
     note_name = note_name.strip().upper()
     note_map = {
-        'C': 0,
-        'C#': 1,
-        'DB': 1,
-        'D': 2,
-        'D#': 3,
-        'EB': 3,
-        'E': 4,
-        'F': 5,
-        'F#': 6,
-        'GB': 6,
-        'G': 7,
-        'G#': 8,
-        'AB': 8,
-        'A': 9,
-        'A#': 10,
-        'BB': 10,
-        'B': 11,
+        "C": 0,
+        "C#": 1,
+        "DB": 1,
+        "D": 2,
+        "D#": 3,
+        "EB": 3,
+        "E": 4,
+        "F": 5,
+        "F#": 6,
+        "GB": 6,
+        "G": 7,
+        "G#": 8,
+        "AB": 8,
+        "A": 9,
+        "A#": 10,
+        "BB": 10,
+        "B": 11,
     }
 
-    m = re.match(r'^([A-G][#B]?)(-?\d+)$', note_name)
+    m = re.match(r"^([A-G][#B]?)(-?\d+)$", note_name)
     if not m:
         return None
     note, octave_str = m.groups()
@@ -194,13 +204,13 @@ def infer_note_from_filename(filename: str) -> Optional[int]:
 
     base = os.path.splitext(os.path.basename(filename))[0]
 
-    match = re.search(r'[ _-]?([A-G][#b]?\-?\d+)', base, re.IGNORECASE)
+    match = re.search(r"[ _-]?([A-G][#b]?\-?\d+)", base, re.IGNORECASE)
     if match:
         midi = name_to_midi(match.group(1))
         if midi is not None:
             return midi
 
-    match = re.search(r'\b(\d{2,3})\b', base)
+    match = re.search(r"\b(\d{2,3})\b", base)
     if match:
         num = int(match.group(1))
         if 0 <= num <= 127:
@@ -211,18 +221,18 @@ def infer_note_from_filename(filename: str) -> Optional[int]:
 def extract_root_note_from_wav(filepath: str) -> Optional[int]:
     """Return the MIDI root note from a WAV file.
 
-    If the ``smpl`` chunk is missing, the function no longer attempts
-    to analyze the audio. It simply returns ``None``.
+    If the ``smpl`` chunk is missing, the function returns ``None``.
+    Pitch detection is handled separately when fixing sample notes.
     """
 
     try:
-        with open(filepath, 'rb') as f:
+        with open(filepath, "rb") as f:
             data = f.read()
-        idx = data.find(b'smpl')
+        idx = data.find(b"smpl")
         if idx != -1 and idx + 36 <= len(data):
             # The MIDI unity note is stored 20 bytes after the 'smpl' tag
             # (after the 8-byte chunk header and three 32-bit fields).
-            note = struct.unpack('<I', data[idx + 20:idx + 24])[0]
+            note = struct.unpack("<I", data[idx + 20 : idx + 24])[0]
             if 0 <= note <= 127:
                 return note
     except Exception as exc:
@@ -233,7 +243,7 @@ def extract_root_note_from_wav(filepath: str) -> Optional[int]:
 
 
 def fix_sample_notes(root: ET.Element, folder: str) -> bool:
-    """Update root/low/high note settings based on file names or WAV metadata."""
+    """Update root/low/high notes using metadata, filenames, or pitch detection."""
 
     changed = False
 
@@ -245,37 +255,53 @@ def fix_sample_notes(root: ET.Element, folder: str) -> bool:
             data = {}
         if not isinstance(data, dict):
             data = {}
-        pads = data.get('pads', {})
+        pads = data.get("pads", {})
         for pad in pads.values():
-            if isinstance(pad, dict) and pad.get('samplePath'):
-                sample_path = pad['samplePath']
-                abs_path = sample_path if os.path.isabs(sample_path) else os.path.join(folder, sample_path)
-                midi = extract_root_note_from_wav(abs_path) or infer_note_from_filename(sample_path)
+            if isinstance(pad, dict) and pad.get("samplePath"):
+                sample_path = pad["samplePath"]
+                abs_path = (
+                    sample_path
+                    if os.path.isabs(sample_path)
+                    else os.path.join(folder, sample_path)
+                )
+                midi = (
+                    extract_root_note_from_wav(abs_path)
+                    or infer_note_from_filename(sample_path)
+                    or detect_fundamental_pitch(abs_path)
+                )
                 if midi is None:
                     continue
-                if pad.get('rootNote') != midi:
-                    pad['rootNote'] = midi
+                if pad.get("rootNote") != midi:
+                    pad["rootNote"] = midi
                     changed = True
-                if pad.get('lowNote') != midi:
-                    pad['lowNote'] = midi
+                if pad.get("lowNote") != midi:
+                    pad["lowNote"] = midi
                     changed = True
-                if pad.get('highNote') != midi:
-                    pad['highNote'] = midi
+                if pad.get("highNote") != midi:
+                    pad["highNote"] = midi
                     changed = True
         if changed:
             pads_elem.text = xml_escape(json.dumps(data, indent=4))
 
-    for inst in root.findall('.//Instrument'):
-        low_elem = inst.find('LowNote')
-        high_elem = inst.find('HighNote')
-        for layer in inst.findall('.//Layer'):
-            sample_elem = layer.find('SampleFile')
-            root_elem = layer.find('RootNote')
+    for inst in root.findall(".//Instrument"):
+        low_elem = inst.find("LowNote")
+        high_elem = inst.find("HighNote")
+        for layer in inst.findall(".//Layer"):
+            sample_elem = layer.find("SampleFile")
+            root_elem = layer.find("RootNote")
             if sample_elem is None or not sample_elem.text:
                 continue
             sample_path = sample_elem.text
-            abs_path = sample_path if os.path.isabs(sample_path) else os.path.join(folder, sample_path)
-            midi = extract_root_note_from_wav(abs_path) or infer_note_from_filename(sample_path)
+            abs_path = (
+                sample_path
+                if os.path.isabs(sample_path)
+                else os.path.join(folder, sample_path)
+            )
+            midi = (
+                extract_root_note_from_wav(abs_path)
+                or infer_note_from_filename(sample_path)
+                or detect_fundamental_pitch(abs_path)
+            )
             if midi is None:
                 continue
             if root_elem is not None and root_elem.text != str(midi):
@@ -289,5 +315,6 @@ def fix_sample_notes(root: ET.Element, folder: str) -> bool:
                 changed = True
 
     return changed
+
 
 # Note: File ends after this line to avoid stray indentation.


### PR DESCRIPTION
## Summary
- support pitch detection when fixing note mappings
- document new **fix_xpm_notes.py** utility
- provide simple CLI script for repairing root note assignments

## Testing
- `black -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687254b63f78832b9f3d152dec9c4b84