### PR TITLE
Add WAV root note metadata writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Additional documentation can be found in the [docs/](docs/) directory, including
   parameters for that modulation slot.
   parameters for that modulation slot. The command-line version exposes the same options via
   `--format`, `--mod-matrix`, and the new `--fix-notes` flag for repairing sample note assignments. The `--verify-map` option can also rebuild programs when extra WAV files are found, assigning them to new keygroups based on their filenames.
-- `fix_xpm_notes.py` – standalone utility to repair root note mappings in existing programs. Point it at a single file or a folder of programs to rewrite each `.xpm` with corrected notes.
+- `fix_xpm_notes.py` – standalone utility to repair root note mappings in existing programs. Use `--update-wav` to also write the detected notes back into each WAV file.
 - `batch_program_editor.py` – batch editor for `.xpm` program files allowing rename, firmware, and format changes.
   This functionality is also accessible from the GUI via **Batch Program Editor...** under Advanced Tools.
   The editor now provides drop-down selectors for **Application Version** and **Format**
@@ -42,7 +42,7 @@ Additional documentation can be found in the [docs/](docs/) directory, including
 - Expansion Builder resizes uploaded artwork to 600x600 if Pillow is installed.
 - Expansion Doctor can rewrite programs to any firmware version and legacy or advanced format.
 - Unknown samples without note metadata are now analyzed to detect their pitch automatically.
-- `fix_xpm_notes.py` uses the same detection logic to correct older programs that were mapped incorrectly.
+- `fix_xpm_notes.py` uses the same detection logic to correct older programs and can embed root notes into WAV files with `--update-wav`.
 
 ## Installation
 

--- a/fix_xpm_notes.py
+++ b/fix_xpm_notes.py
@@ -2,10 +2,11 @@ import os
 import argparse
 import xml.etree.ElementTree as ET
 
-from xpm_parameter_editor import fix_sample_notes, indent_tree
+from xpm_parameter_editor import fix_sample_notes, update_wav_root_notes
+from batch_program_editor import indent_tree
 
 
-def fix_file(path: str) -> bool:
+def fix_file(path: str, write_wav: bool = False) -> bool:
     """Apply note fixes to one XPM file."""
     try:
         tree = ET.parse(path)
@@ -14,10 +15,13 @@ def fix_file(path: str) -> bool:
         print(f"Parse error in {path}: {exc}")
         return False
 
-    if fix_sample_notes(root, os.path.dirname(path)):
+    folder = os.path.dirname(path)
+    if fix_sample_notes(root, folder):
         indent_tree(tree)
         tree.write(path, encoding="utf-8", xml_declaration=True)
         print(f"Fixed {path}")
+        if write_wav:
+            update_wav_root_notes(root, folder)
         return True
     return False
 
@@ -25,16 +29,21 @@ def fix_file(path: str) -> bool:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Fix root notes in XPM programs")
     parser.add_argument("path", help="XPM file or folder")
+    parser.add_argument(
+        "--update-wav",
+        action="store_true",
+        help="Write detected root notes back to WAV metadata",
+    )
     args = parser.parse_args()
 
     target = args.path
     if os.path.isfile(target):
-        fix_file(target)
+        fix_file(target, args.update_wav)
     else:
         for root_dir, _, files in os.walk(target):
             for name in files:
                 if name.lower().endswith(".xpm"):
-                    fix_file(os.path.join(root_dir, name))
+                    fix_file(os.path.join(root_dir, name), args.update_wav)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement `write_root_note_to_wav` and `update_wav_root_notes` helpers
- update `fix_xpm_notes.py` with `--update-wav` option
- document new flag in README
- fix broken import for `indent_tree`

## Testing
- `python -m py_compile fix_xpm_notes.py xpm_parameter_editor.py`
- `pip install numpy soundfile`

------
https://chatgpt.com/codex/tasks/task_e_68725ae5cffc832b840ed4e057b98969