### PR TITLE
Fix missing import for infer_note_from_filename

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -40,6 +40,7 @@ try:
         set_application_version,
         fix_sample_notes,
         find_program_pads,
+        infer_note_from_filename,
     )
     from drumkit_grouping import group_similar_files
     from multi_sample_builder import MultiSampleBuilderWindow, AUDIO_EXTS


### PR DESCRIPTION
## Summary
- add `infer_note_from_filename` to imports in `Gemini wav_TO_XpmV2.py`

## Testing
- `python -m py_compile "Gemini wav_TO_XpmV2.py"`

------
https://chatgpt.com/codex/tasks/task_e_6872ce6c4c90832ba6890e57e2e74f2a