### PR TITLE
Improve keygroup fixer

### DIFF
--- a/xpm_utils.py
+++ b/xpm_utils.py
@@ -64,6 +64,15 @@ def _parse_xpm_for_rebuild(xpm_path):
     if program_name_elem is not None:
         instrument_params["ProgramName"] = program_name_elem.text
 
+    num_elem = root.find(".//KeygroupNumKeygroups")
+    if num_elem is not None and num_elem.text:
+        try:
+            instrument_params["KeygroupNumKeygroups"] = int(num_elem.text)
+        except ValueError:
+            logging.warning(
+                f"Invalid KeygroupNumKeygroups value in {os.path.basename(xpm_path)}: {num_elem.text}"
+            )
+
     inst = root.find(".//Instrument")
     if inst is not None:
         for child in inst:


### PR DESCRIPTION
## Summary
- extend `_parse_xpm_for_rebuild` to read `KeygroupNumKeygroups`
- add `detect_sample_note` helper for metadata or pitch-based note guessing
- rebuild XPMs when declared keygroup count is wrong
- use pitch detection when adding missing samples

## Testing
- `pip install -q -r requirements.txt`
- `git ls-files '*.py' -z | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6872dc3299d8832bae9d3871c320c946