### PR TITLE
Improve filename note inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Additional documentation can be found in the [docs/](docs/) directory, including
 - Expansion Builder resizes uploaded artwork to 600x600 if Pillow is installed.
 - Expansion Doctor can rewrite programs to any firmware version and legacy or advanced format.
 - Unknown samples without note metadata are now analyzed to detect their pitch automatically.
+- Filenames are scanned for multiple note patterns, using the last valid match
+  to determine the MIDI value (e.g. `Piano_A3-64.wav`, `VNLGF41C2.wav`).
 - `fix_xpm_notes.py` uses the same detection logic to correct older programs and can embed root notes into WAV files with `--update-wav`.
 
 ## Installation


### PR DESCRIPTION
## Summary
- improve regex-based note parsing in `infer_note_from_filename`
- use last valid MIDI match or numeric fallback
- document new detection behavior

## Testing
- `python -m py_compile xpm_parameter_editor.py`
- `python - <<'PY'
from xpm_parameter_editor import infer_note_from_filename
print('VNLGF41C2.wav ->', infer_note_from_filename('VNLGF41C2.wav'))
print('Piano_A3-64.wav ->', infer_note_from_filename('Piano_A3-64.wav'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6872e5bc598c832bb1b99e728f01f212