### PR TITLE
Fix rebuild path handling

### DIFF
--- a/xpm_utils.py
+++ b/xpm_utils.py
@@ -51,6 +51,7 @@ def _parse_xpm_for_rebuild(xpm_path):
     """Return sample mappings and base parameters parsed from ``xpm_path``."""
     mappings = []
     instrument_params = {}
+    xpm_path = os.path.abspath(xpm_path)
     xpm_dir = os.path.dirname(xpm_path)
 
     try:
@@ -93,7 +94,7 @@ def _parse_xpm_for_rebuild(xpm_path):
                 if isinstance(pad_data, dict) and pad_data.get("samplePath"):
                     sample_path = pad_data["samplePath"]
                     if sample_path and sample_path.strip():
-                        abs_path = os.path.normpath(os.path.join(xpm_dir, sample_path))
+                        abs_path = os.path.abspath(os.path.join(xpm_dir, sample_path))
                         mappings.append(
                             {
                                 "sample_path": abs_path,
@@ -150,7 +151,7 @@ def _parse_xpm_for_rebuild(xpm_path):
                 if not sample_rel:
                     continue
 
-                abs_path = os.path.normpath(os.path.join(xpm_dir, sample_rel))
+                abs_path = os.path.abspath(os.path.join(xpm_dir, sample_rel))
 
                 layer_params = {}
                 for param_name in LAYER_PARAMS_TO_PRESERVE:


### PR DESCRIPTION
## Summary
- ensure `_parse_xpm_for_rebuild` always resolves the given file to an absolute path
- normalize sample paths when parsing modern and legacy formats

## Testing
- `python -m py_compile "Gemini wav_TO_XpmV2.py" xpm_utils.py sample_mapping_editor.py batch_program_editor.py audio_pitch.py drumkit_grouping.py firmware_profiles.py fix_xpm_notes.py multi_sample_builder.py xpm_parameter_editor.py`

------
https://chatgpt.com/codex/tasks/task_e_6872e783bea4832b8273e8b81d7166d3