### PR TITLE
Fix pad mapping for MPC keygroups

### DIFF
--- a/docs/drum_vs_instrument_keygroups.md
+++ b/docs/drum_vs_instrument_keygroups.md
@@ -153,3 +153,12 @@ If no metadata is found, the tools now analyze the sample itself to detect its f
 
 *Use this guide to ensure the AI agent outputs valid, standards-compliant drum keygroups for MPC expansions.*
 
+## 7. Keygroup Count and Pad Mapping
+
+According to the MPC Standalone User Guide, each sample in an instrument program
+must reside in its own **keygroup**. The value of `KeygroupNumKeygroups` should
+equal the number of `<Instrument>` elements, and the ProgramPads JSON requires a
+`padToInstrument` table so the MPC OS recognizes every keygroup. The repository
+tools rebuild this information automatically when repairing or creating XPM
+files.
+

--- a/xpm_parameter_editor.py
+++ b/xpm_parameter_editor.py
@@ -362,6 +362,24 @@ def fix_sample_notes(root: ET.Element, folder: str) -> bool:
                     if pad.get("highNote") != midi:
                         pad["highNote"] = midi
                         changed = True
+        # Build padToInstrument mapping so the MPC reports the correct number
+        # of keygroups. This is required for older programs that may be
+        # missing this section.
+        pad_to_inst = {}
+        inst_idx = 0
+        for idx in range(128):
+            pad = pads.get(f"value{idx}")
+            if isinstance(pad, dict) and pad.get("samplePath"):
+                pad_to_inst[str(idx)] = inst_idx
+                inst_idx += 1
+        if inst_idx > 0:
+            if data.get("padToInstrument") != pad_to_inst:
+                data["padToInstrument"] = pad_to_inst
+                changed = True
+        elif "padToInstrument" in data:
+            data.pop("padToInstrument")
+            changed = True
+
         if changed:
             pads_elem.text = xml_escape(json.dumps(data, indent=4))
 


### PR DESCRIPTION
## Summary
- rebuild ProgramPads `padToInstrument` mapping when fixing notes
- document keygroup count and pad mapping requirements for MPC

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872ea887928832b9613b6cebc7925d3