### PR TITLE
Add master transpose auto-fix

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -39,6 +39,7 @@ try:
         set_engine_mode,
         set_application_version,
         fix_sample_notes,
+        fix_master_transpose,
         find_program_pads,
         infer_note_from_filename,
         extract_root_note_from_wav,
@@ -4125,6 +4126,8 @@ def batch_edit_programs(folder_path, params):
                     if params.get("fix_notes") and fix_sample_notes(
                         root, os.path.dirname(path)
                     ):
+                        post_change = True
+                    if fix_master_transpose(root, os.path.dirname(path)):
                         post_change = True
                     if "keytrack" in params and set_layer_keytrack(
                         root, params["keytrack"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Additional documentation can be found in the [docs/](docs/) directory, including
   parameters for that modulation slot.
   parameters for that modulation slot. The command-line version exposes the same options via
   `--format`, `--mod-matrix`, and the new `--fix-notes` flag for repairing sample note assignments. The `--verify-map` option can also rebuild programs when extra WAV files are found, assigning them to new keygroups based on their filenames.
-- `fix_xpm_notes.py` – standalone utility to repair root note mappings in existing programs. Use `--update-wav` to also write the detected notes back into each WAV file.
+- `fix_xpm_notes.py` – standalone utility to repair root note mappings and automatically adjust the global transpose when a consistent offset is detected. Use `--update-wav` to also write the detected notes back into each WAV file.
 
 
 ### New in this update
@@ -36,7 +36,7 @@ Additional documentation can be found in the [docs/](docs/) directory, including
 - Unknown samples without note metadata are now analyzed to detect their pitch automatically.
 - Filenames are scanned for multiple note patterns, using the last valid match
   to determine the MIDI value (e.g. `Piano_A3-64.wav`, `VNLGF41C2.wav`).
-- `fix_xpm_notes.py` uses the same detection logic to correct older programs and can embed root notes into WAV files with `--update-wav`.
+- `fix_xpm_notes.py` uses the same detection logic to correct older programs, update the master transpose, and can embed root notes into WAV files with `--update-wav`.
 
 ## Installation
 

--- a/fix_xpm_notes.py
+++ b/fix_xpm_notes.py
@@ -2,7 +2,11 @@ import os
 import argparse
 import xml.etree.ElementTree as ET
 
-from xpm_parameter_editor import fix_sample_notes, update_wav_root_notes
+from xpm_parameter_editor import (
+    fix_sample_notes,
+    update_wav_root_notes,
+    fix_master_transpose,
+)
 from batch_program_editor import indent_tree
 
 
@@ -16,7 +20,15 @@ def fix_file(path: str, write_wav: bool = False) -> bool:
         return False
 
     folder = os.path.dirname(path)
+    changed = False
+
     if fix_sample_notes(root, folder):
+        changed = True
+
+    if fix_master_transpose(root, folder):
+        changed = True
+
+    if changed:
         indent_tree(tree)
         tree.write(path, encoding="utf-8", xml_declaration=True)
         print(f"Fixed {path}")

--- a/xpm_parameter_editor.py
+++ b/xpm_parameter_editor.py
@@ -12,6 +12,7 @@ from typing import Dict, Optional
 from xml.sax.saxutils import escape as xml_escape, unescape as xml_unescape
 
 from audio_pitch import detect_fundamental_pitch
+from collections import Counter
 
 
 def _update_text(elem: Optional[ET.Element], value: Optional[str]) -> bool:
@@ -433,6 +434,80 @@ def fix_sample_notes(root: ET.Element, folder: str) -> bool:
         changed = True
 
     return changed
+
+
+def fix_master_transpose(root: ET.Element, folder: str) -> bool:
+    """Detect and correct a global note offset via ``KeygroupMasterTranspose``."""
+
+    diffs = []
+
+    pads_elem = find_program_pads(root)
+    if pads_elem is not None and pads_elem.text:
+        try:
+            data = json.loads(xml_unescape(pads_elem.text))
+        except json.JSONDecodeError:
+            data = {}
+        pads = data.get("pads", {}) if isinstance(data, dict) else {}
+        for pad in pads.values():
+            if not isinstance(pad, dict):
+                continue
+            sample_path = pad.get("samplePath")
+            root_note = pad.get("rootNote")
+            if sample_path and root_note is not None:
+                abs_path = (
+                    sample_path
+                    if os.path.isabs(sample_path)
+                    else os.path.join(folder, sample_path)
+                )
+                midi = (
+                    extract_root_note_from_wav(abs_path)
+                    or infer_note_from_filename(sample_path)
+                    or detect_fundamental_pitch(abs_path)
+                )
+                if midi is not None:
+                    try:
+                        diffs.append(int(midi) - int(root_note))
+                    except (ValueError, TypeError):
+                        pass
+    for layer in root.findall(".//Layer"):
+        sample_elem = layer.find("SampleFile")
+        root_elem = layer.find("RootNote")
+        if sample_elem is None or root_elem is None:
+            continue
+        sample_path = sample_elem.text
+        root_note = root_elem.text
+        if not sample_path or not root_note:
+            continue
+        abs_path = (
+            sample_path if os.path.isabs(sample_path) else os.path.join(folder, sample_path)
+        )
+        midi = (
+            extract_root_note_from_wav(abs_path)
+            or infer_note_from_filename(sample_path)
+            or detect_fundamental_pitch(abs_path)
+        )
+        if midi is not None:
+            try:
+                diffs.append(int(midi) - int(root_note))
+            except (ValueError, TypeError):
+                pass
+
+    if not diffs:
+        return False
+
+    common_diff, count = Counter(diffs).most_common(1)[0]
+    if count < len(diffs) * 0.6 or common_diff == 0:
+        return False
+
+    elem = root.find(".//KeygroupMasterTranspose")
+    if elem is None:
+        return False
+
+    new_val = f"{float(common_diff):.6f}"
+    if elem.text != new_val:
+        elem.text = new_val
+        return True
+    return False
 
 
 # Note: File ends after this line to avoid stray indentation.


### PR DESCRIPTION
## Summary
- detect and correct global note offsets with `fix_master_transpose`
- call the new helper from `fix_xpm_notes.py` and GUI rebuild path
- document the updated behaviour in README

## Testing
- `python -m py_compile xpm_parameter_editor.py fix_xpm_notes.py "Gemini wav_TO_XpmV2.py"`


------
https://chatgpt.com/codex/tasks/task_e_6873d3e089c4832b840d1cfdb4334f3d