### PR TITLE
Add master transpose auto-fix

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -39,6 +39,7 @@ try:
         set_engine_mode,
         set_application_version,
         fix_sample_notes,
+        fix_master_transpose,
         find_program_pads,
         infer_note_from_filename,
         extract_root_note_from_wav,
@@ -4125,6 +4126,8 @@ def batch_edit_programs(folder_path, params):
                     if params.get("fix_notes") and fix_sample_notes(
                         root, os.path.dirname(path)
                     ):
+                        post_change = True
+                    if fix_master_transpose(root, os.path.dirname(path)):
                         post_change = True
                     if "keytrack" in params and set_layer_keytrack(
                         root, params["keytrack"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Additional documentation can be found in the [docs/](docs/) directory, including
   parameters for that modulation slot.
   parameters for that modulation slot. The command-line version exposes the same options via
   `--format`, `--mod-matrix`, and the new `--fix-notes` flag for repairing sample note assignments. The `--verify-map` option can also rebuild programs when extra WAV files are found, assigning them to new keygroups based on their filenames.
-- `fix_xpm_notes.py` – standalone utility to repair root note mappings in existing programs. Use `--update-wav` to also write the detected notes back into each WAV file.
+- `fix_xpm_notes.py` – standalone utility to repair root note mappings and automatically adjust the global transpose when a consistent offset is detected. Use `--update-wav` to also write the detected notes back into each WAV file.
 
 
 ### New in this update
@@ -36,7 +36,7 @@ Additional documentation can be found in the [docs/](docs/) directory, including
 - Unknown samples without note metadata are now analyzed to detect their pitch automatically.
 - Filenames are scanned for multiple note patterns, using the last valid match
   to determine the MIDI value (e.g. `Piano_A3-64.wav`, `VNLGF41C2.wav`).
-- `fix_xpm_notes.py` uses the same detection logic to correct older programs and can embed root notes into WAV files with `--update-wav`.
+- `fix_xpm_notes.py` uses the same detection logic to correct older programs, update the master transpose, and can embed root notes into WAV files with `--update-wav`.
 
 ## Installation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ When updating the code, confirm that any function signature changes are reflecte
 - The helper function `_parse_xpm_for_rebuild()` in `xpm_utils.py` is now the single entry point
   for parsing both modern and legacy `.xpm` files. Use it whenever sample
   mappings or instrument parameters are required for a rebuild.
+- `fix_master_transpose()` adjusts the global transpose when all samples share a consistent
+  pitch offset, ensuring programs play at the correct keyboard notes.
 
 ### Communication Logs
 

--- a/fix_xpm_notes.py
+++ b/fix_xpm_notes.py
@@ -2,7 +2,11 @@ import os
 import argparse
 import xml.etree.ElementTree as ET
 
-from xpm_parameter_editor import fix_sample_notes, update_wav_root_notes
+from xpm_parameter_editor import (
+    fix_sample_notes,
+    update_wav_root_notes,
+    fix_master_transpose,
+)
 from batch_program_editor import indent_tree
 
 
@@ -16,7 +20,15 @@ def fix_file(path: str, write_wav: bool = False) -> bool:
         return False
 
     folder = os.path.dirname(path)
+    changed = False
+
     if fix_sample_notes(root, folder):
+        changed = True
+
+    if fix_master_transpose(root, folder):
+        changed = True
+
+    if changed:
         indent_tree(tree)
         tree.write(path, encoding="utf-8", xml_declaration=True)
         print(f"Fixed {path}")


### PR DESCRIPTION
## Summary
- detect and correct global note offsets with `fix_master_transpose`
- call the new helper from `fix_xpm_notes.py` and GUI rebuild path
- document the updated behaviour in README
- clarify dev docs about the new helper

## Testing
- `python -m py_compile xpm_parameter_editor.py fix_xpm_notes.py "Gemini wav_TO_XpmV2.py" batch_program_editor.py sample_mapping_editor.py xpm_utils.py multi_sample_builder.py batch_packager.py drumkit_grouping.py audio_pitch.py`
- `python "Gemini wav_TO_XpmV2.py"` *(fails: "ERROR: This application requires a graphical display. Please install Xvfb.")*

------
https://chatgpt.com/codex/tasks/task_e_6873d3e089c4832b840d1cfdb4334f3d