### PR TITLE
Fix Sample Mapping Editor rebuild

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -3530,7 +3530,10 @@ class App(tk.Tk):
         path = filedialog.askopenfilename(
             parent=self.root,
             title="Select XPM Program",
-            filetypes=[("XPM Files", "*.xpm")],
+            filetypes=[
+                ("XPM Files", "*.xpm"),
+                ("Backup XPM", "*.bak *.bak.xpm *.xpm.bak"),
+            ],
             initialdir=self.last_browse_path,
         )
         if path:


### PR DESCRIPTION
## Summary
- keep original XPM as `.bak` when rebuilding
- write rebuilt program with same name as the original
- allow choosing backup files in the sample-mapping editor dialog
- draw piano style keyboard and highlight selected ranges

## Testing
- `python -m py_compile sample_mapping_editor.py 'Gemini wav_TO_XpmV2.py'`
- `python - <<'EOF'
import subprocess, shlex, glob
files = [f for f in glob.glob('*.py')] + [f for f in glob.glob('**/*.py', recursive=True) if '/' in f]
for f in files:
    subprocess.check_call(['python','-m','py_compile',f])
print('done')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6874e8c46b50832b896b01e624c325c6