### PR TITLE
Centralize indent_tree in utils

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -64,6 +64,7 @@ from xpm_utils import (
     LAYER_PARAMS_TO_PRESERVE,
     calculate_key_ranges,
     _parse_xpm_for_rebuild,
+    indent_tree,
 )
 
 
@@ -79,31 +80,6 @@ MPC_WHITE = "#FFFFFF"
 SCW_FRAME_THRESHOLD = 5000
 CREATIVE_FILTER_TYPE_MAP = {"LPF": "0", "HPF": "2", "BPF": "1"}
 EXPANSION_IMAGE_SIZE = (600, 600)  # default icon size
-
-
-def indent_tree(tree, space="  "):
-    """Indent an ElementTree for pretty printing on all Python versions."""
-    if hasattr(ET, "indent"):
-        ET.indent(tree, space=space)
-    else:
-        # Fallback for older Python versions
-        def _indent(elem, level=0):
-            i = "\n" + level * space
-            if len(elem):
-                if not elem.text or not elem.text.strip():
-                    elem.text = i + space
-                if not elem.tail or not elem.tail.strip():
-                    elem.tail = i
-                for child in elem:
-                    _indent(child, level + 1)
-                    if not child.tail or not child.tail.strip():
-                        child.tail = i + space
-                if not elem[-1].tail or not elem[-1].tail.strip():
-                    elem.tail = i
-            elif level and (not elem.tail or not elem.tail.strip()):
-                elem.tail = i
-
-        _indent(tree.getroot())
 
 
 # <editor-fold desc="Logging and Core Helpers">

--- a/batch_program_editor.py
+++ b/batch_program_editor.py
@@ -4,31 +4,8 @@ import logging
 import xml.etree.ElementTree as ET
 import json
 from collections import defaultdict
-from xpm_utils import _parse_xpm_for_rebuild
+from xpm_utils import _parse_xpm_for_rebuild, indent_tree
 from xml.sax.saxutils import escape as xml_escape, unescape as xml_unescape
-
-def indent_tree(tree: ET.ElementTree, space: str = "  ") -> None:
-    """Indent an ElementTree for pretty printing."""
-    if hasattr(ET, "indent"):
-        ET.indent(tree, space=space)
-    else:
-        def _indent(elem: ET.Element, level: int = 0) -> None:
-            i = "\n" + level * space
-            if len(elem):
-                if not elem.text or not elem.text.strip():
-                    elem.text = i + space
-                for child in elem:
-                    _indent(child, level + 1)
-                if not child.tail or not child.tail.strip():  # type: ignore
-                    child.tail = i  # type: ignore
-            if level and (not elem.tail or not elem.tail.strip()):
-                elem.tail = i
-
-        _indent(tree.getroot())
-
-    root = tree.getroot()
-    if not (root.tail and root.tail.endswith("\n")):
-        root.tail = "\n"
 
 from xpm_parameter_editor import (
     set_layer_keytrack,

--- a/fix_xpm_notes.py
+++ b/fix_xpm_notes.py
@@ -7,7 +7,7 @@ from xpm_parameter_editor import (
     update_wav_root_notes,
     fix_master_transpose,
 )
-from batch_program_editor import indent_tree
+from xpm_utils import indent_tree
 
 
 def fix_file(path: str, write_wav: bool = False) -> bool:

--- a/sample_mapping_editor.py
+++ b/sample_mapping_editor.py
@@ -11,7 +11,8 @@ from xpm_parameter_editor import (
     fix_sample_notes,
     fix_master_transpose,
 )
-from batch_program_editor import build_program_pads_json, indent_tree
+from batch_program_editor import build_program_pads_json
+from xpm_utils import indent_tree
 from firmware_profiles import fw_program_parameters, get_pad_settings
 from xml.sax.saxutils import escape as xml_escape
 import json

--- a/xpm_utils.py
+++ b/xpm_utils.py
@@ -5,6 +5,34 @@ import json
 import xml.etree.ElementTree as ET
 from xml.sax.saxutils import escape as xml_escape, unescape as xml_unescape
 
+
+def indent_tree(tree: ET.ElementTree, space: str = "  ") -> None:
+    """Indent an ElementTree for pretty printing on all Python versions."""
+    if hasattr(ET, "indent"):
+        ET.indent(tree, space=space)
+    else:
+        def _indent(elem: ET.Element, level: int = 0) -> None:
+            i = "\n" + level * space
+            if len(elem):
+                if not elem.text or not elem.text.strip():
+                    elem.text = i + space
+                if not elem.tail or not elem.tail.strip():
+                    elem.tail = i
+                for child in elem:
+                    _indent(child, level + 1)
+                    if not child.tail or not child.tail.strip():
+                        child.tail = i + space
+                if not elem[-1].tail or not elem[-1].tail.strip():
+                    elem.tail = i
+            elif level and (not elem.tail or not elem.tail.strip()):
+                elem.tail = i
+
+        _indent(tree.getroot())
+
+    root = tree.getroot()
+    if not (root.tail and root.tail.endswith("\n")):
+        root.tail = "\n"
+
 # Preserve these layer parameters when rebuilding
 LAYER_PARAMS_TO_PRESERVE = [
     "VelStart",


### PR DESCRIPTION
## Summary
- add `indent_tree` to `xpm_utils.py`
- remove local `indent_tree` helpers
- import `indent_tree` from `xpm_utils` across the repo

## Testing
- `python -m py_compile $(find . -name '*.py' -not -path './.git/*')`

------
https://chatgpt.com/codex/tasks/task_e_6874f8f7944c832ba3b33bf25a9643b4