### PR TITLE
Warn mac users about Python 3.13

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -4203,6 +4203,26 @@ def batch_edit_programs(folder_path, params):
 
 
 def main():
+    if sys.platform == "darwin" and sys.version_info[:2] >= (3, 13):
+        try:
+            root = tk.Tk()
+            root.withdraw()
+            messagebox.showwarning(
+                "Python 3.13 Warning",
+                (
+                    "Python 3.13 on macOS has known Tkinter issues that can "
+                    "cause crashes. It is recommended to run this script with "
+                    "Python 3.12 or earlier."
+                ),
+            )
+            root.destroy()
+        except Exception:
+            print(
+                "WARNING: Python 3.13 on macOS may be unstable with Tkinter. "
+                "Use Python 3.12 or earlier for best results.",
+                file=sys.stderr,
+            )
+
     if sys.platform == "linux" and "DISPLAY" not in os.environ:
         try:
             subprocess.run(

--- a/README.md
+++ b/README.md
@@ -47,9 +47,14 @@ Additional documentation can be found in the [docs/](docs/) directory, including
    The package list includes **soundfile** and **numpy** which are required for automatic pitch detection.
 2. Launch the GUI:
    ```bash
-    python "Gemini wav_TO_XpmV2.py"
-    ```
+   python "Gemini wav_TO_XpmV2.py"
+   ```
    The filename contains a space after `Gemini`, so quoting the command is required.
+
+   **macOS Python Version Warning:** Recent builds of Python 3.13 on macOS ship
+   with an unstable Tkinter framework that can crash when running this
+   application. If you encounter a sudden "NSInvalidArgumentException" at
+   startup, install Python 3.12 or earlier and run the script again.
 
 ## Development Notes
 


### PR DESCRIPTION
## Summary
- warn about Python 3.13 on macOS in the main script
- document Python version issue in README

## Testing
- `python -m py_compile 'Gemini wav_TO_XpmV2.py'`

------
https://chatgpt.com/codex/tasks/task_e_68751968adcc832bb71e3c45171cb87f