### PR TITLE
Fix macOS Python 3.13 warning crash

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -4204,24 +4204,12 @@ def batch_edit_programs(folder_path, params):
 
 def main():
     if sys.platform == "darwin" and sys.version_info[:2] >= (3, 13):
-        try:
-            root = tk.Tk()
-            root.withdraw()
-            messagebox.showwarning(
-                "Python 3.13 Warning",
-                (
-                    "Python 3.13 on macOS has known Tkinter issues that can "
-                    "cause crashes. It is recommended to run this script with "
-                    "Python 3.12 or earlier."
-                ),
-            )
-            root.destroy()
-        except Exception:
-            print(
-                "WARNING: Python 3.13 on macOS may be unstable with Tkinter. "
-                "Use Python 3.12 or earlier for best results.",
-                file=sys.stderr,
-            )
+        print(
+            "WARNING: Python 3.13 on macOS has known Tkinter issues that can "
+            "cause crashes. Run this script with Python 3.12 or earlier for "
+            "best results.",
+            file=sys.stderr,
+        )
 
     if sys.platform == "linux" and "DISPLAY" not in os.environ:
         try:

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ Additional documentation can be found in the [docs/](docs/) directory, including
 
    **macOS Python Version Warning:** Recent builds of Python 3.13 on macOS ship
    with an unstable Tkinter framework that can crash when running this
-   application. If you encounter a sudden "NSInvalidArgumentException" at
-   startup, install Python 3.12 or earlier and run the script again.
+   application. The script prints a warning if Python 3.13 is detected. If you
+   encounter a sudden "NSInvalidArgumentException" at startup, install Python
+   3.12 or earlier and run the script again.
 
 ## Development Notes
 


### PR DESCRIPTION
## Summary
- replace the early Tkinter warning dialog with a console print
- document the console warning in README

## Testing
- `python -m py_compile "Gemini wav_TO_XpmV2.py"`
- `black --check "Gemini wav_TO_XpmV2.py"`


------
https://chatgpt.com/codex/tasks/task_e_6875217902d4832bab2e3e25c5645461