### PR TITLE
Fix missing Quick Edits frame

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -3374,6 +3374,8 @@ class App(tk.Tk):
             text="Batch Program Fixer...",
             command=lambda: self.open_window(BatchProgramFixerWindow),
         ).grid(row=1, column=0, columnspan=2, sticky="ew", padx=2, pady=2)
+
+    def create_quick_edits_frame(self, parent):
         frame = ttk.LabelFrame(parent, text="Quick Edits", padding="10")
         frame.grid(row=4, column=0, sticky="ew", pady=5)
         frame.grid_columnconfigure(0, weight=1)


### PR DESCRIPTION
## Summary
- implement `create_quick_edits_frame` in the App class
- use the new method when initializing the GUI

## Testing
- `python -m py_compile "Gemini wav_TO_XpmV2.py"`
- `python - <<'EOF'
import importlib.util
spec = importlib.util.spec_from_file_location('module','Gemini wav_TO_XpmV2.py')
mod = importlib.util.module_from_spec(spec)
spec.loader.exec_module(mod)
print('method exists:', hasattr(mod.App, 'create_quick_edits_frame'))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6877acb2f1d0832bacb2e4a165469321