### PR TITLE
Fix macOS file dialog crash

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -891,7 +891,7 @@ class ExpansionBuilderWindow(tk.Toplevel):
         path = filedialog.askopenfilename(
             parent=self,
             title="Select Image",
-            filetypes=[("Image Files", "*.jpg *.jpeg *.png")],
+            filetypes=[("Image Files", ("*.jpg", "*.jpeg", "*.png"))],
         )
         if path:
             self.image_var.set(path)
@@ -1664,7 +1664,7 @@ class BatchProgramEditorWindow(tk.Toplevel):
         path = filedialog.askopenfilename(
             parent=self,
             title="Select Mod Matrix JSON",
-            filetypes=[("JSON Files", "*.json"), ("All Files", "*")],
+            filetypes=[("JSON Files", "*.json"), ("All Files", "*.*")],
             initialdir=self.master.last_browse_path,
         )
         if path:

--- a/sample_mapping_checker.py
+++ b/sample_mapping_checker.py
@@ -80,7 +80,10 @@ class SampleMappingCheckerWindow(tk.Toplevel):
     def open_program(self):
         path = filedialog.askopenfilename(
             parent=self,
-            filetypes=[('XPM Files', '*.xpm'), ('Backup XPM', '*.bak *.bak.xpm *.xpm.bak')],
+            filetypes=[
+                ('XPM Files', '*.xpm'),
+                ('Backup XPM', ('*.bak', '*.bak.xpm', '*.xpm.bak')),
+            ],
         )
         if not path:
             return

--- a/sample_mapping_editor.py
+++ b/sample_mapping_editor.py
@@ -76,7 +76,10 @@ class SampleMappingEditorWindow(tk.Toplevel):
             self.tree.insert('', 'end', values=(os.path.basename(m['sample_path']), midi_to_name(m['root_note'])))
 
     def add_samples(self):
-        paths = filedialog.askopenfilenames(parent=self, filetypes=[('Audio', '*.wav *.aif *.aiff *.flac *.mp3 *.ogg *.m4a')])
+        paths = filedialog.askopenfilenames(
+            parent=self,
+            filetypes=[('Audio', ('*.wav', '*.aif', '*.aiff', '*.flac', '*.mp3', '*.ogg', '*.m4a'))]
+        )
         for path in paths:
             if not path:
                 continue


### PR DESCRIPTION
## Summary
- sanitize filetype patterns for Tk dialogs

## Testing
- `python3 -m py_compile "Gemini wav_TO_XpmV2.py" sample_mapping_checker.py sample_mapping_editor.py`

------
https://chatgpt.com/codex/tasks/task_e_6877b713575c832ba5efe05b8a21c6cf