### PR TITLE
Fix macOS filedialog crash

### DIFF
--- a/Gemini wav_TO_XpmV2.py
+++ b/Gemini wav_TO_XpmV2.py
@@ -891,7 +891,7 @@ class ExpansionBuilderWindow(tk.Toplevel):
         path = filedialog.askopenfilename(
             parent=self,
             title="Select Image",
-            filetypes=[("Image Files", ("*.jpg", "*.jpeg", "*.png"))],
+            filetypes=[("Image Files", "*.jpg *.jpeg *.png")],
         )
         if path:
             self.image_var.set(path)

--- a/sample_mapping_checker.py
+++ b/sample_mapping_checker.py
@@ -82,7 +82,8 @@ class SampleMappingCheckerWindow(tk.Toplevel):
             parent=self,
             filetypes=[
                 ('XPM Files', '*.xpm'),
-                ('Backup XPM', ('*.bak', '*.bak.xpm', '*.xpm.bak')),
+                ('Backup XPM', '*.bak *.xpm.bak *.bak.xpm'),
+                ('All Files', '*.*'),
             ],
         )
         if not path:


### PR DESCRIPTION
## Summary
- fix Sample Mapping Checker file dialog filetypes
- fix Expansion Builder image browser filetypes

## Testing
- `python -m py_compile 'Gemini wav_TO_XpmV2.py' sample_mapping_checker.py`

------
https://chatgpt.com/codex/tasks/task_e_687a33c117d4832b8764e4723fb2b7c8